### PR TITLE
Do not terminate the program when some method fails

### DIFF
--- a/src/Audience.vala
+++ b/src/Audience.vala
@@ -84,7 +84,7 @@ namespace Audience {
                         cache.make_directory ();
                     }
                 } catch (Error e) {
-                    error (e.message);
+                    warning (e.message);
                 }
 
                 mainwindow = new Window ();

--- a/src/Objects/Video.vala
+++ b/src/Objects/Video.vala
@@ -153,7 +153,7 @@ namespace Audience.Objects {
             try {
                 new Thread<void*>.try (null, run);
             } catch (Error e) {
-                error (e.message);
+                warning (e.message);
             }
 
             yield;

--- a/src/Services/Inhibitor.vala
+++ b/src/Services/Inhibitor.vala
@@ -39,7 +39,7 @@ public class Audience.Services.Inhibitor :  Object {
         try {
             screensaver_iface = Bus.get_proxy_sync (BusType.SESSION, IFACE, IFACE_PATH, DBusProxyFlags.NONE);
         } catch (Error e) {
-            error ("Could not start screensaver interface: %s", e.message);
+            warning ("Could not start screensaver interface: %s", e.message);
         }
     }
 
@@ -59,7 +59,7 @@ public class Audience.Services.Inhibitor :  Object {
                 simulate_activity ();
                 debug ("Inhibiting screen");
             } catch (Error e) {
-                error ("Could not inhibit screen: %s", e.message);
+                warning ("Could not inhibit screen: %s", e.message);
             }
         }
     }
@@ -71,7 +71,7 @@ public class Audience.Services.Inhibitor :  Object {
                 screensaver_iface.UnInhibit (inhibit_cookie);
                 debug ("Uninhibiting screen");
             } catch (Error e) {
-                error ("Could not uninhibit screen: %s", e.message);
+                warning ("Could not uninhibit screen: %s", e.message);
             }
         }
     }
@@ -90,7 +90,7 @@ public class Audience.Services.Inhibitor :  Object {
                     debug ("Simulating activity");
                     screensaver_iface.SimulateUserActivity ();
                 } catch (Error e) {
-                    error ("Could not simulate user activity: %s", e.message);
+                    warning ("Could not simulate user activity: %s", e.message);
                 }
             } else {
                 simulator_started = false;

--- a/src/Services/LibraryManager.vala
+++ b/src/Services/LibraryManager.vala
@@ -187,7 +187,7 @@ namespace Audience.Services {
                         }
                     }
                 } catch (Error e) {
-                    error (e.message);
+                    warning (e.message);
                 }
             }
         }

--- a/src/Services/LibraryManager.vala
+++ b/src/Services/LibraryManager.vala
@@ -59,7 +59,7 @@ namespace Audience.Services {
             try {
                 regex_year = new Regex ("\\(\\d\\d\\d\\d(?=(\\)$))");
             } catch (Error e) {
-                error (e.message);
+                warning (e.message);
             }
             thumbler = new DbusThumbnailer ();
 

--- a/src/ZeitgeistManager.vala
+++ b/src/ZeitgeistManager.vala
@@ -34,7 +34,7 @@ namespace Audience {
             try {
                 apps = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.zeitgeist.Engine", "/org/gnome/zeitgeist/blacklist");
             } catch (Error e) {
-                error (e.message);
+                warning (e.message);
             }
         }
 

--- a/src/ZeitgeistManager.vala
+++ b/src/ZeitgeistManager.vala
@@ -48,7 +48,7 @@ namespace Audience {
                     }
                 }
             } catch (Error e) {
-                error (e.message);
+                warning (e.message);
             }
 
             return false;


### PR DESCRIPTION
We should not call `error` since it terminates the program, we call `warning` instead. Fixes #25 and #36.