### PR TITLE
Disallow setting playback before start

### DIFF
--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -329,7 +329,7 @@ namespace Audience {
             var duration = playback.duration;
             var progress = playback.progress;
             var new_progress = ((duration * progress) + (double)seconds)/duration;
-            playback.progress = double.min (new_progress, 1.0);
+            playback.progress = new_progress.clamp (0.0, 1.0);
         }
 
         public Widgets.Playlist get_playlist_widget () {


### PR DESCRIPTION
navigating video with arrow keys back before 00:00 opened welcome screen