### PR TITLE
Make video fullscreen on maximize

### DIFF
--- a/src/Window.vala
+++ b/src/Window.vala
@@ -205,14 +205,13 @@ public class Audience.Window : Gtk.Window {
                 header.visible = !player_page.fullscreened;
             }
 
-            /*/ FIXME: Remove comments once gala bug is fixed: https://bugs.launchpad.net/gala/+bug/1602722
             if (Gdk.WindowState.MAXIMIZED in e.changed_mask) {
                 bool currently_maximixed = Gdk.WindowState.MAXIMIZED in e.new_window_state;
 
                 if (main_stack.get_visible_child () == player_page && currently_maximixed) {
                    fullscreen ();
                 }
-            }*/
+            }
 
             return false;
         });

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -203,6 +203,10 @@ public class Audience.Window : Gtk.Window {
             if (Gdk.WindowState.FULLSCREEN in e.changed_mask) {
                 player_page.fullscreened = Gdk.WindowState.FULLSCREEN in e.new_window_state;
                 header.visible = !player_page.fullscreened;
+
+                if (!player_page.fullscreened) {
+                    unmaximize ();
+                }
             }
 
             if (Gdk.WindowState.MAXIMIZED in e.changed_mask) {


### PR DESCRIPTION
Restores functionality of making the video player fullscreen when maximizing the window

~Blocked, depends on https://github.com/elementary/gala/pull/58 or the window will break~

The bug is now fixed in Juno, so once Videos is done supporting Loki this can be merged  