### PR TITLE
Settings popover bugfixes

### DIFF
--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -93,18 +93,21 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     }
 
     private void on_subtitles_changed () {
-        if (subtitles.active < 0)
+        if (subtitles.active < 0) {
             return;
+        }
 
-        if (subtitles.active_id == "none")
+        if (subtitles.active_id == "none") {
             playback.subtitle_track = -1;
-        else
+        } else {
             playback.subtitle_track = subtitles.active;
+        }
     }
 
     private void on_languages_changed () {
-        if (languages.active < 0 || languages.active_id == "def")
+        if (languages.active < 0 || languages.active_id == "def") {
             return;
+        }
 
         playback.audio_stream = languages.active;
     }
@@ -112,8 +115,9 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     private void setup_text () {
         subtitles.changed.disconnect (on_subtitles_changed);
 
-        if (subtitles.model.iter_n_children (null) > 0)
+        if (subtitles.model.iter_n_children (null) > 0) {
             subtitles.remove_all ();
+        }
 
         uint track = 1;
         playback.get_subtitle_tracks ().foreach ((lang) => {
@@ -124,10 +128,11 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
 
         int count = subtitles.model.iter_n_children (null); 
         subtitles.sensitive = count > 1;
-        if (subtitles.sensitive && (playback.subtitle_track >= 0))
+        if (subtitles.sensitive && (playback.subtitle_track >= 0)) {
             subtitles.active = playback.subtitle_track;
-        else
+        } else {
             subtitles.active = count - 1;
+        }
 
         subtitles.changed.connect (on_subtitles_changed);
     }
@@ -135,8 +140,9 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     private void setup_audio () {
         languages.changed.disconnect (on_languages_changed);
 
-        if (languages.model.iter_n_children (null) > 0)
+        if (languages.model.iter_n_children (null) > 0) {
             languages.remove_all ();
+        }
 
         uint track = 1;
         playback.get_audio_streams ().foreach ((lang) => {
@@ -148,8 +154,9 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         if (languages.sensitive) {
             languages.active = playback.audio_stream;
         } else {
-            if (count != 0)
+            if (count != 0) {
                 languages.remove_all ();
+            }
             languages.append ("def", _("Default"));
             languages.active = 0;
         }

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -73,6 +73,10 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
             playback.set_subtitle_uri (external_subtitle_file.get_uri ());
         });
 
+        playback.notify["uri"].connect (() => {
+            is_setup = false;
+        });
+
         playback.notify["subtitle_uri"].connect (() => {
             external_subtitle_file.select_uri (playback.subtitle_uri);
         });
@@ -152,6 +156,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     }
 
     public void next_audio () {
+        setup ();
         int count = languages.model.iter_n_children (null);
         if (count > 0) {
             languages.active = (languages.active + 1) % count;
@@ -159,6 +164,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     }
 
     public void next_text () {
+        setup ();
         int count = subtitles.model.iter_n_children (null);
         if (count > 0) {
             subtitles.active = (subtitles.active + 1) % count;

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -73,10 +73,6 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
             playback.set_subtitle_uri (external_subtitle_file.get_uri ());
         });
 
-        playback.notify["uri"].connect (() => {
-            is_setup = false;
-        });
-
         playback.notify["subtitle-uri"].connect (() => {
             external_subtitle_file.select_uri (playback.subtitle_uri);
         });

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -77,7 +77,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
             is_setup = false;
         });
 
-        playback.notify["subtitle_uri"].connect (() => {
+        playback.notify["subtitle-uri"].connect (() => {
             external_subtitle_file.select_uri (playback.subtitle_uri);
         });
 

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -152,24 +152,16 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
     }
 
     public void next_audio () {
-        int current = languages.active;
-        if (current < languages.model.iter_n_children (null) - 1) {
-            current++;
-        } else {
-            current = 0;
+        int count = languages.model.iter_n_children (null);
+        if (count > 0) {
+            languages.active = (languages.active + 1) % count;
         }
-
-        languages.active = current;
     }
 
     public void next_text () {
-        int current = subtitles.active;
-        if (current < subtitles.model.iter_n_children (null)) {
-            current++;
-        } else {
-            current = 0;
+        int count = subtitles.model.iter_n_children (null);
+        if (count > 0) {
+            subtitles.active = (subtitles.active + 1) % count;
         }
-
-        subtitles.active = current;
     }
 }


### PR DESCRIPTION
fixed cycling over subtitle and audio lists with 'A' and 'S' keys:
* it worked properly only after you opened settings popover
* you could cycle to empty item in subtitles or over 2 audio items when combobox is disabled

- subtitle changed property did not notify before

Looks like this also fixes #35 