### PR TITLE
Remove deprecated app_icon field

### DIFF
--- a/src/Audience.vala
+++ b/src/Audience.vala
@@ -50,7 +50,6 @@ namespace Audience {
 
             Intl.setlocale (LocaleCategory.ALL, "");
 
-            app_icon = "multimedia-video-player";
             app_launcher = "org.pantheon.audience.desktop";
             application_id = "io.elementary.videos";
         }


### PR DESCRIPTION
It was used for the about dialog, however that was removed by #34 