### PR TITLE
Fix 'Back' button label not shown at first

### DIFF
--- a/src/Widgets/NavigationButton.vala
+++ b/src/Widgets/NavigationButton.vala
@@ -27,6 +27,7 @@ namespace Audience {
 
         construct {
             can_focus = false;
+            label = "";
             valign = Gtk.Align.CENTER;
             vexpand = false;
             this.get_style_context ().add_class ("back-button");


### PR DESCRIPTION
1. open Videos
2. click Browse Library
... there's tiny navigation button with no text at first

No idea why gtk doesn't show label at first even though it is set. Just initializing label property apparently fixes the issue.