### PR TITLE
Improve popover size for different video ratios

### DIFF
--- a/src/Widgets/Player/PreviewPopover.vala
+++ b/src/Widgets/Player/PreviewPopover.vala
@@ -76,7 +76,11 @@ public class Audience.Widgets.PreviewPopover : Gtk.Popover {
         ((ClutterGst.Content) aspect_ratio).player = playback;
         video_actor.content = aspect_ratio;
         ((ClutterGst.Content) aspect_ratio).size_change.connect ((width, height) => {
-            clutter.set_size_request (200, (int)(((double) (height*200))/((double) width)));
+            if (width > 0 && height > 0) {
+                double diagonal = Math.sqrt((width * width) + (height * height));
+                double k = 230 / diagonal; // for 16:9 ratio it produces width of ~200px
+                clutter.set_size_request ((int)(width * k), (int)(height * k));
+            }
         });
 
         video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));


### PR DESCRIPTION
Popover width was always 200px. That would make popover too big for vertical videos.

This PR calculates popover size by fitting video ratio inside circle with radius 115px. I picked this radius so that popover showing 16:9 video stays same size as it is now.