### PR TITLE
meson: add missing 'gee-0.8' dependency

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,7 @@ executable(
         dependency('clutter-gst-3.0'),
         dependency('clutter-gtk-1.0'),
         dependency('gdk-x11-3.0'),
+        dependency('gee-0.8'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
         dependency('granite'),


### PR DESCRIPTION
This is necessary because videos uses Gee directly, and granite built with
meson is more conservative with the linker flags it includes.

See:
- src/DiskManager.vala#L35
- src/Services/LibraryManager.vala#L38
- etc.