### PR TITLE
Use new methods of screen inhibiting

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,6 +36,8 @@ namespace Audience {
             Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
             this.flags |= GLib.ApplicationFlags.HANDLES_OPEN;
             settings = new Settings ();
+
+            Services.Inhibitor.initialize (this);
         }
 
         private static App app; // global App instance

--- a/src/Services/Inhibitor.vala
+++ b/src/Services/Inhibitor.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2019 elementary LLC. (https://elementary.io)
+ * Copyright 2019 elementary, Inc. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Library General Public License as published by
@@ -51,7 +51,7 @@ public class Audience.Services.Inhibitor :  Object {
         }
     }
 
-    public static Inhibitor get_instance () {
+    public static unowned Inhibitor get_instance () {
         return instance;
     }
 
@@ -59,7 +59,7 @@ public class Audience.Services.Inhibitor :  Object {
         if (screensaver_iface != null && !inhibited) {
             try {
                 inhibited = true;
-                screensaver_inhibit_cookie = screensaver_iface.Inhibit ("io.elementary.videos", "Playing movie");
+                screensaver_inhibit_cookie = screensaver_iface.Inhibit (application.application_id, "Playing movie");
                 suspend_inhibit_cookie = application.inhibit (application.get_active_window (), Gtk.ApplicationInhibitFlags.SUSPEND, "Playing Movie");
                 debug ("Inhibiting screen");
             } catch (Error e) {


### PR DESCRIPTION
This PR removes the previous method of inhibiting using `simulate_activity`. Simulating user activity is bad because it keeps apps like Slack or others from displaying that "User is Idle" message, and  

To fully inhibit the session, two things need to happen:
 
- Using `screensaver_iface.Inhibit ("io.elementary.videos", "Playing movie");`, the screen saver gets inhibited and the screen won't turn to black after the timeout
- And using `Gtk.application.inhibit (application.get_active_window (), Gtk.ApplicationInhibitFlags.SUSPEND, "Playing Movie");` will make it so the automatic suspend never happens

## Things I've tested:
- Inhibits properly when playing a video
- Computer can suspend when video is paused or app quits while playing 

## Things i tried that didn't work

- I tried to get rid of the dbus interface and use the IDLE flag mentioned in  `https://valadoc.org/gtk+-3.0/Gtk.ApplicationInhibitFlags.html`, but that does not inhibit the screensaver from starting
- Tried using another dbus interface `org.gnome.SessionManager` but Gtk.App.Inhibit communicates using the same methods 

Fixes #107 as well since i'm now checking if the `screensaver_inhibit_cookie` is null