### PR TITLE
NEW: queque next episodes when playing from library

### DIFF
--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -99,14 +99,6 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
         }
     }
 
-    public bool autoqueque_next {
-        get {
-            return playlist_popover.autoqueque_next.active;
-        }
-        set {
-            playlist_popover.autoqueque_next.active = value;
-        }
-    }
 
     public BottomBar (ClutterGst.Playback playback) {
         this.events |= Gdk.EventMask.POINTER_MOTION_MASK;

--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -99,12 +99,12 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
         }
     }
 
-    public bool autoplay_next {
+    public bool autoqueque_next {
         get {
-            return playlist_popover.autoplay_next.active;
+            return playlist_popover.autoqueque_next.active;
         }
         set {
-            playlist_popover.autoplay_next.active = value;
+            playlist_popover.autoqueque_next.active = value;
         }
     }
 

--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -99,6 +99,15 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
         }
     }
 
+    public bool autoplay_next {
+        get {
+            return playlist_popover.autoplay_next.active;
+        }
+        set {
+            playlist_popover.autoplay_next.active = value;
+        }
+    }
+
     public BottomBar (ClutterGst.Playback playback) {
         this.events |= Gdk.EventMask.POINTER_MOTION_MASK;
         this.events |= Gdk.EventMask.LEAVE_NOTIFY_MASK;

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -34,15 +34,6 @@ namespace Audience {
             }
         }
 
-        public bool autoqueque_next {
-            get{
-                return bottom_bar.autoqueque_next;
-            }
-
-            set{
-                bottom_bar.autoqueque_next = value;
-            }
-        }
 
         public bool playing {
             get {
@@ -217,11 +208,6 @@ namespace Audience {
                             playback.playing = false;
                             settings.last_stopped = 0;
                             ended ();
-                        }
-                    } else if (autoqueque_next) {
-                        var playlist_widget = get_playlist_widget ();
-                        if (playlist_widget.get_current () >= playlist_widget.get_all_items ().length () - 1) {
-                            playlist_widget.queque_n_next_aviable_videos (1);
                         }
                     }
                     return false;

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -34,13 +34,13 @@ namespace Audience {
             }
         }
 
-        public bool autoplay_next {
+        public bool autoqueque_next {
             get{
-                return bottom_bar.autoplay_next;
+                return bottom_bar.autoqueque_next;
             }
 
             set{
-                bottom_bar.autoplay_next = value;
+                bottom_bar.autoqueque_next = value;
             }
         }
 
@@ -213,16 +213,15 @@ namespace Audience {
                         if (repeat) {
                             string file = get_playlist_widget ().get_first_item ().get_uri ();
                             App.get_instance ().mainwindow.open_files ({ File.new_for_uri (file) });
-                        } else if (autoplay_next) {
-                            if (!get_playlist_widget ().autoplay_next()) {
-                                playback.playing = false;
-                                settings.last_stopped = 0;
-                                ended ();
-                            }
                         } else {
                             playback.playing = false;
                             settings.last_stopped = 0;
                             ended ();
+                        }
+                    } else if (autoqueque_next) {
+                        var playlist_widget = get_playlist_widget ();
+                        if (playlist_widget.get_current () >= playlist_widget.get_all_items ().length () - 1) {
+                            playlist_widget.queque_n_next_aviable_videos (1);
                         }
                     }
                     return false;

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -34,6 +34,16 @@ namespace Audience {
             }
         }
 
+        public bool autoplay_next {
+            get{
+                return bottom_bar.autoplay_next;
+            }
+
+            set{
+                bottom_bar.autoplay_next = value;
+            }
+        }
+
         public bool playing {
             get {
                 return playback.playing;
@@ -203,6 +213,12 @@ namespace Audience {
                         if (repeat) {
                             string file = get_playlist_widget ().get_first_item ().get_uri ();
                             App.get_instance ().mainwindow.open_files ({ File.new_for_uri (file) });
+                        } else if (autoplay_next) {
+                            if (!get_playlist_widget ().autoplay_next()) {
+                                playback.playing = false;
+                                settings.last_stopped = 0;
+                                ended ();
+                            }
                         } else {
                             playback.playing = false;
                             settings.last_stopped = 0;

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -89,6 +89,40 @@ namespace Audience.Widgets {
             return false;
         }
 
+        public bool autoplay_next() {
+            // We get the path of the last file we played.
+            // From this path we will extract the folder where it's placed and then we will look for the next file of the folder.
+            File original_file = File.new_for_uri(this.get_all_items().last ().data);
+            string original_filename = original_file.get_path();
+            File original_dir = original_file.get_parent();
+            string original_dirname = original_dir.get_path();
+            try {
+                FileEnumerator enumerator = original_dir.enumerate_children ("standard::*", FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null);
+                FileInfo info = null;
+                File newfile;
+                bool original_found = false;
+                while ((info = enumerator.next_file (null)) != null) {
+                    if (original_dirname+"/"+info.get_name () == original_filename) {
+                        original_found = true;
+                    } else if (original_found) {
+                        newfile = File.new_for_path(original_dirname+"/"+info.get_name ());
+                        if (newfile.query_info("*", 0).get_content_type().split("/")[0] == "video") {
+                            this.add_item(newfile);
+                            current++;
+                            play (newfile);
+                            return true;
+                        }
+                    }
+                }
+            } catch (Error e) {
+	            print ("Error: %s\n", e.message);
+                current = 0;
+                return false;
+            }
+            current = 0;
+            return false;
+        }
+
         public void previous () {
             Gtk.TreeIter iter;
             if (playlist.get_iter_from_string (out iter, (this.current - 1).to_string ())){

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -89,36 +89,6 @@ namespace Audience.Widgets {
             return false;
         }
 
-        public int queque_n_next_aviable_videos(int nfiles) {
-            // We get the path of the last file we played.
-            // From this path we will extract the folder where it's placed and then we will look for the next file of the folder.
-            File original_file = File.new_for_uri (this.get_all_items ().last ().data);
-            string original_filename = original_file.get_path ();
-            File original_dir = original_file.get_parent ();
-            string original_dirname = original_dir.get_path ();
-            int quequed_files = 0;
-            try {
-                FileEnumerator enumerator = original_dir.enumerate_children ("standard::*", FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null);
-                FileInfo info = null;
-                File newfile;
-                bool original_found = false;
-                while ((info = enumerator.next_file (null)) != null && quequed_files < nfiles) {
-                    if (original_dirname + "/" + info.get_name () == original_filename) {
-                        original_found = true;
-                    } else if (original_found) {
-                        newfile = File.new_for_path(original_dirname + "/" + info.get_name ());
-                        if (newfile.query_info ("*", 0).get_content_type ().split ("/")[0] == "video") {
-                            this.add_item(newfile);
-                            quequed_files++;
-                        }
-                    }
-                }
-            } catch (Error e) {
-	            print ("Error: %s\n", e.message);
-                return 0;
-            }
-            return quequed_files;
-        }
 
         public void previous () {
             Gtk.TreeIter iter;

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -89,38 +89,35 @@ namespace Audience.Widgets {
             return false;
         }
 
-        public bool autoplay_next() {
+        public int queque_n_next_aviable_videos(int nfiles) {
             // We get the path of the last file we played.
             // From this path we will extract the folder where it's placed and then we will look for the next file of the folder.
-            File original_file = File.new_for_uri(this.get_all_items().last ().data);
-            string original_filename = original_file.get_path();
-            File original_dir = original_file.get_parent();
-            string original_dirname = original_dir.get_path();
+            File original_file = File.new_for_uri (this.get_all_items ().last ().data);
+            string original_filename = original_file.get_path ();
+            File original_dir = original_file.get_parent ();
+            string original_dirname = original_dir.get_path ();
+            int quequed_files = 0;
             try {
                 FileEnumerator enumerator = original_dir.enumerate_children ("standard::*", FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null);
                 FileInfo info = null;
                 File newfile;
                 bool original_found = false;
-                while ((info = enumerator.next_file (null)) != null) {
-                    if (original_dirname+"/"+info.get_name () == original_filename) {
+                while ((info = enumerator.next_file (null)) != null && quequed_files < nfiles) {
+                    if (original_dirname + "/" + info.get_name () == original_filename) {
                         original_found = true;
                     } else if (original_found) {
-                        newfile = File.new_for_path(original_dirname+"/"+info.get_name ());
-                        if (newfile.query_info("*", 0).get_content_type().split("/")[0] == "video") {
+                        newfile = File.new_for_path(original_dirname + "/" + info.get_name ());
+                        if (newfile.query_info ("*", 0).get_content_type ().split ("/")[0] == "video") {
                             this.add_item(newfile);
-                            current++;
-                            play (newfile);
-                            return true;
+                            quequed_files++;
                         }
                     }
                 }
             } catch (Error e) {
 	            print ("Error: %s\n", e.message);
-                current = 0;
-                return false;
+                return 0;
             }
-            current = 0;
-            return false;
+            return quequed_files;
         }
 
         public void previous () {

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -41,7 +41,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         rep.set_image (new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON));
         rep.set_tooltip_text (_("Enable Repeat"));
 
-        Gtk.Label autoqueque_next_label = new Gtk.Label (_("Auto queque aviable videos:"));
+        Gtk.Label autoqueque_next_label = new Gtk.Label (_("Auto queue available videos:"));
         autoqueque_next = new Gtk.Switch ();
 
         playlist_scrolled = new Gtk.ScrolledWindow (null, null);

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -21,6 +21,7 @@
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
     public Playlist playlist;
     public Gtk.ToggleButton rep;
+    public Gtk.ToggleButton autoplay_next;
     private Gtk.ScrolledWindow playlist_scrolled;
     private Gtk.Button dvd;
 
@@ -39,6 +40,10 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         rep = new Gtk.ToggleButton ();
         rep.set_image (new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON));
         rep.set_tooltip_text (_("Enable Repeat"));
+
+        autoplay_next = new Gtk.ToggleButton ();
+        autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playback-stop-symbolic", Gtk.IconSize.BUTTON));
+        autoplay_next.set_tooltip_text (_("Enable Autoplay Next File"));
 
         playlist_scrolled = new Gtk.ScrolledWindow (null, null);
         playlist_scrolled.set_min_content_height (100);
@@ -68,10 +73,22 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
             }
         });
 
+        autoplay_next.toggled.connect ( () => {
+            /* app.autoplay_next = autoplay_next.active; */
+            if (autoplay_next.active) {
+                autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
+                autoplay_next.set_tooltip_text (_("Disable Autoplay Next File"));
+            } else {
+                autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playback-stop-symbolic", Gtk.IconSize.BUTTON));
+                autoplay_next.set_tooltip_text (_("Enable Autoplay Next File"));
+            }
+        });
+
         grid.attach (playlist_scrolled, 0, 0, 7, 1);
         grid.attach (fil, 0, 1, 1, 1);
         grid.attach (dvd, 1, 1, 1, 1);
         grid.attach (rep, 6, 1, 1, 1);
+        grid.attach (autoplay_next, 5, 1, 1, 1);
 
         add (grid);
 

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -21,7 +21,7 @@
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
     public Playlist playlist;
     public Gtk.ToggleButton rep;
-    public Gtk.ToggleButton autoplay_next;
+    public Gtk.ToggleButton autoqueque_next;
     private Gtk.ScrolledWindow playlist_scrolled;
     private Gtk.Button dvd;
 
@@ -41,9 +41,10 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         rep.set_image (new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON));
         rep.set_tooltip_text (_("Enable Repeat"));
 
-        autoplay_next = new Gtk.ToggleButton ();
-        autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playback-stop-symbolic", Gtk.IconSize.BUTTON));
-        autoplay_next.set_tooltip_text (_("Enable Autoplay Next File"));
+        autoqueque_next = new Gtk.ToggleButton ();
+        autoqueque_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
+        autoqueque_next.set_tooltip_text (_("Enable auto queque next videos"));
+        autoqueque_next.active = false;
 
         playlist_scrolled = new Gtk.ScrolledWindow (null, null);
         playlist_scrolled.set_min_content_height (100);
@@ -73,14 +74,16 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
             }
         });
 
-        autoplay_next.toggled.connect ( () => {
-            /* app.autoplay_next = autoplay_next.active; */
-            if (autoplay_next.active) {
-                autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
-                autoplay_next.set_tooltip_text (_("Disable Autoplay Next File"));
+        autoqueque_next.toggled.connect ( () => {
+            /* app.autoqueque_next = autoqueque_next.active; */
+            if (autoqueque_next.active) {
+                autoqueque_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
+                autoqueque_next.set_tooltip_text (_("Disable auto queque next videos"));
+                if (playlist.get_current () >= playlist.get_all_items ().length () - 1) {
+                    playlist.queque_n_next_aviable_videos (1);
+                }
             } else {
-                autoplay_next.set_image (new Gtk.Image.from_icon_name ("media-playback-stop-symbolic", Gtk.IconSize.BUTTON));
-                autoplay_next.set_tooltip_text (_("Enable Autoplay Next File"));
+                autoqueque_next.set_tooltip_text (_("Enable auto queque next videos"));
             }
         });
 
@@ -88,7 +91,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         grid.attach (fil, 0, 1, 1, 1);
         grid.attach (dvd, 1, 1, 1, 1);
         grid.attach (rep, 6, 1, 1, 1);
-        grid.attach (autoplay_next, 5, 1, 1, 1);
+        grid.attach (autoqueque_next, 5, 1, 1, 1);
 
         add (grid);
 

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -21,7 +21,7 @@
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
     public Playlist playlist;
     public Gtk.ToggleButton rep;
-    public Gtk.ToggleButton autoqueque_next;
+    public Gtk.Switch autoqueque_next;
     private Gtk.ScrolledWindow playlist_scrolled;
     private Gtk.Button dvd;
 
@@ -41,10 +41,8 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         rep.set_image (new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON));
         rep.set_tooltip_text (_("Enable Repeat"));
 
-        autoqueque_next = new Gtk.ToggleButton ();
-        autoqueque_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
-        autoqueque_next.set_tooltip_text (_("Enable auto queque next videos"));
-        autoqueque_next.active = false;
+        Gtk.Label autoqueque_next_label = new Gtk.Label (_("Auto queque aviable videos:"));
+        autoqueque_next = new Gtk.Switch ();
 
         playlist_scrolled = new Gtk.ScrolledWindow (null, null);
         playlist_scrolled.set_min_content_height (100);
@@ -74,24 +72,21 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
             }
         });
 
-        autoqueque_next.toggled.connect ( () => {
+        autoqueque_next.notify["active"].connect ( () => {
             /* app.autoqueque_next = autoqueque_next.active; */
             if (autoqueque_next.active) {
-                autoqueque_next.set_image (new Gtk.Image.from_icon_name ("media-playlist-consecutive-symbolic", Gtk.IconSize.BUTTON));
-                autoqueque_next.set_tooltip_text (_("Disable auto queque next videos"));
                 if (playlist.get_current () >= playlist.get_all_items ().length () - 1) {
                     playlist.queque_n_next_aviable_videos (1);
                 }
-            } else {
-                autoqueque_next.set_tooltip_text (_("Enable auto queque next videos"));
             }
         });
 
         grid.attach (playlist_scrolled, 0, 0, 7, 1);
         grid.attach (fil, 0, 1, 1, 1);
         grid.attach (dvd, 1, 1, 1, 1);
-        grid.attach (rep, 6, 1, 1, 1);
+        grid.attach (autoqueque_next_label, 4, 1, 1, 1);
         grid.attach (autoqueque_next, 5, 1, 1, 1);
+        grid.attach (rep, 6, 1, 1, 1);
 
         add (grid);
 

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -21,7 +21,6 @@
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
     public Playlist playlist;
     public Gtk.ToggleButton rep;
-    public Gtk.Switch autoqueque_next;
     private Gtk.ScrolledWindow playlist_scrolled;
     private Gtk.Button dvd;
 
@@ -40,9 +39,6 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         rep = new Gtk.ToggleButton ();
         rep.set_image (new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON));
         rep.set_tooltip_text (_("Enable Repeat"));
-
-        Gtk.Label autoqueque_next_label = new Gtk.Label (_("Auto queue available videos:"));
-        autoqueque_next = new Gtk.Switch ();
 
         playlist_scrolled = new Gtk.ScrolledWindow (null, null);
         playlist_scrolled.set_min_content_height (100);
@@ -72,20 +68,10 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
             }
         });
 
-        autoqueque_next.notify["active"].connect ( () => {
-            /* app.autoqueque_next = autoqueque_next.active; */
-            if (autoqueque_next.active) {
-                if (playlist.get_current () >= playlist.get_all_items ().length () - 1) {
-                    playlist.queque_n_next_aviable_videos (1);
-                }
-            }
-        });
 
         grid.attach (playlist_scrolled, 0, 0, 7, 1);
         grid.attach (fil, 0, 1, 1, 1);
         grid.attach (dvd, 1, 1, 1, 1);
-        grid.attach (autoqueque_next_label, 4, 1, 1, 1);
-        grid.attach (autoqueque_next, 5, 1, 1, 1);
         grid.attach (rep, 6, 1, 1, 1);
 
         add (grid);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -470,6 +470,14 @@ public class Audience.Window : Gtk.Window {
         welcome_page.refresh ();
     }
 
+    public void clear_playlist() {
+        player_page.get_playlist_widget().clear_items();
+    }
+
+    public void append_to_playlist(File file) {
+        player_page.append_to_playlist(file);
+    }
+
     public void navigate_back () {
         double progress = player_page.get_progress ();
         if (progress > 0) {


### PR DESCRIPTION
# Binge mode

When a file is played from the library, all next episodes are added to the queue. By this, users cab star to watch a show without the need of select the next episode every time an episode finish.

![imgl1](https://user-images.githubusercontent.com/25721962/55675590-3a371200-58c5-11e9-9d0e-98ec7497582c.png)

![imgl2](https://user-images.githubusercontent.com/25721962/55675591-3c996c00-58c5-11e9-8dbd-b5be93d156bc.png)


## Other changes

- When a file is played from the library, the playlist is cleared before adding all the next episodes of the selected file.