### PR TITLE
PlaylistItem cleanup and revealer

### DIFF
--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -143,9 +143,9 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
             string name = row.filename;
             if (name == current_file) {
                 current_played = count;
-                row.set_play_state ();
+                row.is_playing = true;
             } else {
-                row.set_unplay_state ();
+                row.is_playing = false;
             }
             count++;
         }

--- a/src/Widgets/Player/PlaylistItem.vala
+++ b/src/Widgets/Player/PlaylistItem.vala
@@ -48,7 +48,6 @@ public class Audience.Widgets.PlaylistItem : Gtk.ListBoxRow {
         grid.margin = 3;
         grid.margin_bottom = grid.margin_top = 6;
         grid.column_spacing = 6;
-        grid.row_spacing = 3;
         grid.add (play_revealer);
         grid.add (track_name_label);
 


### PR DESCRIPTION
* Use a property for `is_playing`
* bind play icon revealer to `is_playing` property
* Reduce variable scope
* Organize
* Use `add` instead of attach since we're only packing two widgets here
* Move `show_all` to the `construct` block
* Remove `row_spacing` since we never pack things vertically