### PR TITLE
Handle time jumping even if the user clicks above/below the slider

### DIFF
--- a/src/Widgets/Player/TimeWidget.vala
+++ b/src/Widgets/Player/TimeWidget.vala
@@ -59,6 +59,14 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
         });
 
         scale.button_release_event.connect ((event) => {
+            // Manually set the slider value using the click event
+            // dimensions. The slider widget doesn't set itself
+            // when clicked too much above/below the slider itself.
+            // This isn't necessarily a bug with the slider widget,
+            // but this is the desired behavior for this slider in
+            // the video player
+            scale.set_value (event.x / scale.get_range_rect ().width);
+
             main_playback.progress = scale.get_value ();
             return false;
         });

--- a/src/Widgets/Player/TimeWidget.vala
+++ b/src/Widgets/Player/TimeWidget.vala
@@ -58,7 +58,7 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
             return false;
         });
 
-        scale.button_release_event.connect ((event) => {
+        this.button_release_event.connect ((event) => {
             // Manually set the slider value using the click event
             // dimensions. The slider widget doesn't set itself
             // when clicked too much above/below the slider itself.


### PR DESCRIPTION
This PR fixes #171 by setting the slider value manually given the click event rather than relying on the Slider class to properly change the value.

Current behavior: https://imgur.com/RbeIs67
New behavior: https://imgur.com/3GWXq8I