### PR TITLE
Use custom css for TimeWidget scale

### DIFF
--- a/src/Widgets/Player/TimeWidget.vala
+++ b/src/Widgets/Player/TimeWidget.vala
@@ -23,7 +23,7 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
     unowned ClutterGst.Playback main_playback;
     public Audience.Widgets.PreviewPopover preview_popover {get; private set;}
 
-    public const string trough_css = """
+    public const string TROUGH_CSS = """
         scale trough {
             border-radius: 12px;
             background-color: alpha (#000, 0.05);
@@ -56,7 +56,7 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
 
         var scale_css_provider = new Gtk.CssProvider ();
         try {
-            scale_css_provider.load_from_data (trough_css);
+            scale_css_provider.load_from_data (TROUGH_CSS);
             scale.get_style_context ().add_provider (scale_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
         } catch (GLib.Error e) {
             warning ("Failed to load css %s", e.message);

--- a/src/Widgets/Player/TimeWidget.vala
+++ b/src/Widgets/Player/TimeWidget.vala
@@ -23,6 +23,18 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
     unowned ClutterGst.Playback main_playback;
     public Audience.Widgets.PreviewPopover preview_popover {get; private set;}
 
+    public const string trough_css = """
+        scale trough {
+            border-radius: 12px;
+            background-color: alpha (#000, 0.05);
+            box-shadow: none;
+            margin: 0px 0px;
+            padding: 6px 6px;
+            min-height: 6px;
+            min-width: 5px;
+        }
+    """;
+
     public TimeWidget (ClutterGst.Playback main_playback) {
         Object (playback_duration: 0.0);
 
@@ -41,6 +53,14 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
                 preview_popover.relative_to = scale;
             }
         });
+
+        var scale_css_provider = new Gtk.CssProvider ();
+        try {
+            scale_css_provider.load_from_data (trough_css);
+            scale.get_style_context ().add_provider (scale_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+        } catch (GLib.Error e) {
+            warning ("Failed to load css %s", e.message);
+        }
 
         scale.vexpand = true;
 

--- a/src/Widgets/Player/TimeWidget.vala
+++ b/src/Widgets/Player/TimeWidget.vala
@@ -25,13 +25,15 @@ public class Audience.Widgets.TimeWidget : Granite.SeekBar {
 
     public const string TROUGH_CSS = """
         scale trough {
-            border-radius: 12px;
-            background-color: alpha (#000, 0.05);
-            box-shadow: none;
-            margin: 0px 0px;
-            padding: 6px 6px;
-            min-height: 6px;
+            margin: 0px 6px;
+            padding: 0px 6px;
+            min-height: 10px;
             min-width: 5px;
+                box-shadow:
+                inset 0 0 0 1px alpha (#000, 0.3),
+                inset 0 0 0 2px alpha (#000, 0.03),
+                0 1px 0 0 alpha (@bg_highlight_color, 0.3),
+                0 0 6px 0px alpha (#000, 0.01);
         }
     """;
 


### PR DESCRIPTION
Fixes #171

An alternative solution to #172 

The margin and box shadow widths are reduced to zero.

In master, the popover shows when the pointer enters the shadow/margin area but these do not trigger a change in scale value when clicked.  This fixes this by removing these areas and increasing the padding to compensate (partially).  A small padding is also inserted so that the time value does not butt up against the trough so much.

Requires UX team to approve the exact custom css.