### PR TITLE
Keep the application on the player page when a new video is opened while another on is playing

### DIFF
--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -119,7 +119,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         foreach (Gtk.Widget item in get_children ()) {
             remove (item);
         }
-        
+
         if (should_stop) {
             stop_video ();
         }

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -114,13 +114,15 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
     }
 
-    public void clear_items () {
+    public void clear_items (bool should_stop = true) {
         current = 0;
         foreach (Gtk.Widget item in get_children ()) {
             remove (item);
         }
-
-        stop_video ();
+        
+        if (should_stop) {
+            stop_video ();
+        }
     }
 
     public File? get_first_item () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -356,7 +356,7 @@ public class Audience.Window : Gtk.Window {
 
     public void open_files (File[] files, bool clear_playlist_items = false, bool force_play = true) {
         if (clear_playlist_items) {
-            clear_playlist ();
+            clear_playlist (false);
         }
 
         string[] videos = {};
@@ -504,8 +504,8 @@ public class Audience.Window : Gtk.Window {
         }
     }
 
-    public void clear_playlist () {
-        player_page.get_playlist_widget ().clear_items ();
+    public void clear_playlist (bool should_stop = true) {
+        player_page.get_playlist_widget ().clear_items (should_stop);
     }
 
     public void append_to_playlist (File file) {


### PR DESCRIPTION
See #219 for issue description

Notes:
There might be a better solution to this problem (adding an extra signal when a video starts playing and navigating the application to the player page when it is emitted), but I didn't want (and had the time) to refactor the application, so I implemented a much simpler solution. It prevents `Playlist.clear_items()` from emitting `stop_video()` (taking the application back to the welcome page) in the specific case that is described in the issue - all other use-cases remain unchanged. I hope this is acceptable.