### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,14 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), language:'c')
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
 
 subdir('src')
 meson.add_install_script('meson/post_install.py')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,6 +31,9 @@ namespace Audience {
 
         construct {
             Intl.setlocale (LocaleCategory.ALL, "");
+            Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+            Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+            Intl.textdomain (GETTEXT_PACKAGE);
             application_id = "io.elementary.videos";
         }
 

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 executable(
     meson.project_name(),
+    config_file,
     'Application.vala',
     'Consts.vala',
     'DiskManager.vala',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are packaging this in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch, I hope this patch can also help in Flatpak packaging if the community decides to do this in the future.

See also: https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580

Thanks in advance for reviewing this :-)

---

P.s.: To be honest, I personally want similar patches to be applied in every components of Pantheon as [I already did in downstream](https://github.com/NixOS/nixpkgs/pull/130380/files), including the wingpanel indicators and the switchboard plugs, that will probably leads to tons of PRs (maybe a kind of spamming), if this troubles the community I sincerely apologize for this.