### PR TITLE
Flatpak: Restrict Filesystem Access

### DIFF
--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -5,7 +5,7 @@ sdk: io.elementary.Sdk
 command: io.elementary.videos
 finish-args:
   - '--filesystem=xdg-cache/thumbnails:ro'
-  - '--filesystem=xdg-videos:ro
+  - '--filesystem=xdg-videos:ro'
 
   - '--share=ipc'
   - '--socket=fallback-x11'


### PR DESCRIPTION
i believe we don't need more access than this:

* `xdg-videos` for the library view.
* `xdg-cache/thumbnails` for the thumbnails.

Fixes #243