### PR TITLE
Flatpak: Allow Write Access to Library and Thumbnails Cache Folders

### DIFF
--- a/data/io.elementary.videos.appdata.xml.in
+++ b/data/io.elementary.videos.appdata.xml.in
@@ -36,6 +36,14 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.8.1" date="2021-12-11" urgency="medium">
+      <description>
+        <p>Other updates:</p>
+        <ul>
+          <li>Fix an issue with removing videos from library</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.8.0" date="2021-10-28" urgency="medium">
       <description>
         <p>New features:</p>

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -4,8 +4,8 @@ runtime-version: '6'
 sdk: io.elementary.Sdk
 command: io.elementary.videos
 finish-args:
-  - '--filesystem=xdg-cache/thumbnails:ro'
-  - '--filesystem=xdg-videos:ro'
+  - '--filesystem=xdg-cache/thumbnails'
+  - '--filesystem=xdg-videos'
 
   - '--share=ipc'
   - '--socket=fallback-x11'

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -86,4 +86,8 @@ namespace Audience {
 
         return discoverer_info;
     }
+
+    public static bool is_sandboxed () {
+        return FileUtils.test ("/.flatpak-info", FileTest.EXISTS);
+    }
 }


### PR DESCRIPTION
we need to have write access to move files to trash.

fixes #282.