### PR TITLE
Flatpak: Add `org.freedesktop.Platform.ffmpeg-full` Extension Point

### DIFF
--- a/data/io.elementary.videos.appdata.xml.in
+++ b/data/io.elementary.videos.appdata.xml.in
@@ -36,6 +36,14 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.8.1" date="2021-12-11" urgency="medium">
+      <description>
+        <p>Other updates:</p>
+        <ul>
+          <li>Added support for the org.freedesktop.Platfrom.ffmpeg-full extension</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.8.0" date="2021-10-28" urgency="medium">
       <description>
         <p>New features:</p>

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -20,6 +20,7 @@ finish-args:
 
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
+    no-autodownload: true
     directory: lib/ffmpeg
     version: '20.08'
     add-ld-path: '.'

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -17,9 +17,18 @@ finish-args:
   - '--talk-name=org.gnome.SettingsDaemon'
 
   - '--metadata=X-DConf=migrate-path=/io/elementary/videos/'
+
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    version: '20.08'
+    add-ld-path: '.'
+
 modules:
   - name: videos
     buildsystem: meson
+    post-install:
+      - 'mkdir -p /app/lib/ffmpeg'
     sources:
       - type: dir
         path: .


### PR DESCRIPTION
Allows videos to use the codecs provided by the extension when installed.

Should fix #281.