### PR TITLE
Port to GTK4

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -31,8 +31,8 @@ executable(
 
     dependencies: [
         dependency('clutter-gst-3.0'),
-        dependency('clutter-gtk-1.0'),
-        dependency('gdk-x11-3.0'),
+        # dependency('clutter-gtk-1.0'),
+        # dependency('gdk-x11-3.0'),
         dependency('gee-0.8'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
@@ -41,8 +41,8 @@ executable(
         dependency('gstreamer-pbutils-1.0'),
         dependency('gstreamer-video-1.0'),
         dependency('gstreamer-tag-1.0'),
-        dependency('gtk+-3.0', version: '>=3.22'),
-        dependency('libhandy-1'),
+        dependency('gtk4'),
+        dependency('libadwaita-1'),
 
         meson.get_compiler('vala').find_library('posix'),
         meson.get_compiler('c').find_library('m', required : false)


### PR DESCRIPTION
Depends on Granite
Where we are blocked:
- [ ] Replace Gtk.TargetEntry as this no longer exists in GTK4
- [ ] Replace Gtk.DragContext and Gtk.SelectionData for same reasons.
- [ ] Replace Gtk.FileChooserButton as it is also dropped
- [ ] Replace Gtk.Menu Instances
- [ ] Replace Event handling as EventButton is dropped
- [ ] Lastly, GtkClutter is still in GTK3 which hinders porting 