### PR TITLE
Flatpak: update runtime to 6.1

### DIFF
--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -1,6 +1,6 @@
 app-id: io.elementary.videos
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '6.1'
 sdk: io.elementary.Sdk
 command: io.elementary.videos
 finish-args:

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -22,7 +22,7 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     no-autodownload: true
     directory: lib/ffmpeg
-    version: '20.08'
+    version: '21.08'
     add-ld-path: '.'
 
 modules:


### PR DESCRIPTION
May fix #291

We're shipping GL 21.08 and I think this expects 20.08 https://github.com/elementary/os/blob/master/etc/config/hooks/live/001-install-flatpaks.chroot