### PR TITLE
Control: revert changes to build-deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,16 @@ Source: io.elementary.videos
 Section: video
 Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io>
-Build-Depends: debhelper (>= 10.5.1)
+Build-Depends: debhelper (>= 10.5.1),
+                intltool,
+                libclutter-gst-3.0-dev,
+                libclutter-gtk-1.0-dev,
+                libgranite-dev,
+                libgstreamer-plugins-base1.0-dev,
+                libgstreamer1.0-dev,
+                libgtk-3-dev,
+                meson,
+                valac (>= 0.28.0)
 Standards-Version: 4.1.1
 Homepage: https://github.com/elementary/videos
 


### PR DESCRIPTION
Re-add build-deps. Even though we don't actually need these to build the package, it makes `apt build-dep` work and fixes the gettext action