### PR TITLE
BottomBar: Remove get_preferred_width

### DIFF
--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -146,18 +146,6 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
         }
     }
 
-    public override void get_preferred_width (out int minimum_width, out int natural_width) {
-        base.get_preferred_width (out minimum_width, out natural_width);
-        if (parent.get_window () == null) {
-            return;
-        }
-
-        var width = parent.get_window ().get_width ();
-        if (width > 0 && width >= minimum_width) {
-            natural_width = width;
-        }
-    }
-
     public void reveal_control () {
         if (child_revealed == false) {
             set_reveal_child (true);


### PR DESCRIPTION
I can't see any difference without this code. Not sure what it's supposed to do that hexpand would already do? The earliest available commit for this mentions porting to Gtk 3.12, so I'm guessing this is just leftovers?