### PR TITLE
Utils: Remove unused session manager interface

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -24,14 +24,6 @@ public interface GnomeMediaKeys : GLib.Object {
     public signal void media_player_key_pressed (string application, string key);
 }
 
-[DBus (name = "org.gnome.SessionManager")]
-public interface GnomeSessionManager : GLib.Object {
-    [DBus (name = "isSessionRunning")]
-    public abstract bool is_session_running () throws GLib.Error;
-    public abstract uint32 inhibit (string app_id, uint32 toplevel_xid, string reason, uint32 flags) throws GLib.Error;
-    public abstract void uninhibit (uint32 inhibit_cookie) throws GLib.Error;
-}
-
 namespace Audience {
     private const int DISCOVERER_TIMEOUT = 5;
 


### PR DESCRIPTION
We're using Gtk.Application.Inhibit, so this is unused