### PR TITLE
Application: store repeat state in an Action

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,10 +29,12 @@ namespace Audience {
         public const string ACTION_NEXT = "action-next";
         public const string ACTION_PLAY_PAUSE = "action-play-pause";
         public const string ACTION_PREVIOUS = "action-previous";
+        public const string ACTION_REPEAT = "action-repeat";
 
         private const ActionEntry[] ACTION_ENTRIES = {
             { ACTION_PLAY_PAUSE, action_play_pause, null, "false" },
             { ACTION_NEXT, action_next },
+            { ACTION_REPEAT, null, null, "false"},
             { ACTION_PREVIOUS, action_previous }
         };
 

--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -49,15 +49,6 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
         }
     }
 
-    public bool repeat {
-        get {
-            return playlist_popover.rep.active;
-        }
-        set {
-            playlist_popover.rep.active = value;
-        }
-    }
-
     public BottomBar (ClutterGst.Playback playback) {
         play_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.BUTTON) {
             action_name = App.ACTION_PREFIX + App.ACTION_PLAY_PAUSE,

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -203,7 +203,8 @@ namespace Audience {
                 Idle.add (() => {
                     playback.progress = 0;
                     if (!get_playlist_widget ().next ()) {
-                        if (bottom_bar.repeat) {
+                        var repeat_action = Application.get_default ().lookup_action (Audience.App.ACTION_REPEAT);
+                        if (repeat_action.get_state ().get_boolean ()) {
                             string file = get_playlist_widget ().get_first_item ().get_uri ();
                             ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file) });
                         } else {

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -19,7 +19,6 @@
 
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
     public Playlist playlist { get; private set; }
-    public Gtk.ToggleButton rep { get; private set; }
 
     private Gtk.Button dvd;
     private const int HEIGHT_OFFSET = 300;
@@ -36,7 +35,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         var clear_playlist_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.BUTTON);
         clear_playlist_button.tooltip_text = _("Clear Playlist");
 
-        rep = new Gtk.ToggleButton () {
+        var rep = new Gtk.ToggleButton () {
             action_name = App.ACTION_PREFIX + App.ACTION_REPEAT,
             image = new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON),
             tooltip_text = _("Enable Repeat")

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -37,6 +37,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         clear_playlist_button.tooltip_text = _("Clear Playlist");
 
         rep = new Gtk.ToggleButton () {
+            action_name = App.ACTION_PREFIX + App.ACTION_REPEAT,
             image = new Gtk.Image.from_icon_name ("media-playlist-no-repeat-symbolic", Gtk.IconSize.BUTTON),
             tooltip_text = _("Enable Repeat")
         };


### PR DESCRIPTION
Store repeat state in a GLib.Action so that classes aren't reaching across each other and we're not relying on UI elements to store state