### PR TITLE
Create PlaybackManager

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -117,11 +117,11 @@ namespace Audience {
         }
 
         private void action_next () {
-            mainwindow.player_page.get_playlist_widget ().next ();
+            PlaybackManager.get_default ().next ();
         }
 
         private void action_previous () {
-            mainwindow.player_page.get_playlist_widget ().previous ();
+            PlaybackManager.get_default ().previous ();
         }
 
         private void on_bus_acquired (DBusConnection connection, string name) {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -9,6 +9,7 @@ public class Audience.PlaybackManager : Object {
     public signal void next ();
     public signal void previous ();
     public signal void set_subtitle (string uri);
+    public signal void clear_playlist (bool should_stop = true);
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -4,15 +4,17 @@
  */
 
 public class Audience.PlaybackManager : Object {
+    public signal void item_added ();
     public signal bool next ();
+    public signal File? get_first_item ();
     public signal void clear_playlist (bool should_stop = true);
-    public signal void play (File path);
+    public signal void play (File file);
     public signal void previous ();
+    public signal void queue_file (File file);
     public signal void save_playlist ();
     public signal void set_current (string current_file);
     public signal void set_subtitle (string uri);
     public signal void stop ();
-    public signal File? get_first_item ();
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2022 elementary, Inc. (https://elementary.io)
+ */
+
+public class Audience.PlaybackManager : Object {
+    public signal void play (File path);
+    public signal void stop ();
+
+    private static PlaybackManager? _instance;
+    public static PlaybackManager get_default () {
+        if (_instance == null) {
+            _instance = new PlaybackManager ();
+        }
+
+        return _instance;
+    }
+
+    private PlaybackManager () {}
+}

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -10,6 +10,7 @@ public class Audience.PlaybackManager : Object {
     public signal void previous ();
     public signal void set_subtitle (string uri);
     public signal void clear_playlist (bool should_stop = true);
+    public signal void save_playlist ();
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -18,6 +18,8 @@ public class Audience.PlaybackManager : Object {
     public signal void set_subtitle (string uri);
     public signal void stop ();
 
+    public string? subtitle_uri { get; set; }
+
     private static GLib.Once<PlaybackManager> instance;
     public static unowned PlaybackManager get_default () {
         return instance.once (() => { return new PlaybackManager (); });

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -40,7 +40,7 @@ public class Audience.PlaybackManager : Object {
             return false;
         }
 
-        foreach (string ext in SUBTITLE_EXTENSIONS) {
+        foreach (unowned string ext in SUBTITLE_EXTENSIONS) {
             if (uri.down ().has_suffix (ext)) {
                 return true;
             }

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -6,7 +6,7 @@
 public class Audience.PlaybackManager : Object {
     public signal void play (File path);
     public signal void stop ();
-    public signal void next ();
+    public signal bool next ();
     public signal void previous ();
     public signal void set_subtitle (string uri);
     public signal void clear_playlist (bool should_stop = true);

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -6,6 +6,8 @@
 public class Audience.PlaybackManager : Object {
     public signal void play (File path);
     public signal void stop ();
+    public signal void next ();
+    public signal void previous ();
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -15,7 +15,6 @@ public class Audience.PlaybackManager : Object {
     public signal void queue_file (File file);
     public signal void save_playlist ();
     public signal void set_current (string current_file);
-    public signal void set_subtitle (string uri);
     public signal void stop ();
 
     public string? subtitle_uri { get; set; }
@@ -29,7 +28,7 @@ public class Audience.PlaybackManager : Object {
 
     public void append_to_playlist (File file) {
         if (is_subtitle (file.get_uri ())) {
-            set_subtitle (file.get_uri ());
+            subtitle_uri = file.get_uri ();
         } else {
             queue_file (file);
         }

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -26,4 +26,26 @@ public class Audience.PlaybackManager : Object {
     }
 
     private PlaybackManager () {}
+
+    public void append_to_playlist (File file) {
+        if (is_subtitle (file.get_uri ())) {
+            set_subtitle (file.get_uri ());
+        } else {
+            queue_file (file);
+        }
+    }
+
+    private bool is_subtitle (string uri) {
+        if (uri.length < 4 || uri.get_char (uri.length - 4) != '.') {
+            return false;
+        }
+
+        foreach (string ext in SUBTITLE_EXTENSIONS) {
+            if (uri.down ().has_suffix (ext)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -8,6 +8,8 @@ public class Audience.PlaybackManager : Object {
     public signal File? get_first_item ();
     public signal void clear_playlist (bool should_stop = true);
     public signal void item_added ();
+    public signal void next_audio ();
+    public signal void next_text ();
     public signal void play (File file);
     public signal void previous ();
     public signal void queue_file (File file);

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2022 elementary, Inc. (https://elementary.io)
  */
 

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -4,13 +4,15 @@
  */
 
 public class Audience.PlaybackManager : Object {
-    public signal void play (File path);
-    public signal void stop ();
     public signal bool next ();
-    public signal void previous ();
-    public signal void set_subtitle (string uri);
     public signal void clear_playlist (bool should_stop = true);
+    public signal void play (File path);
+    public signal void previous ();
     public signal void save_playlist ();
+    public signal void set_current (string current_file);
+    public signal void set_subtitle (string uri);
+    public signal void stop ();
+    public signal File? get_first_item ();
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -16,13 +16,9 @@ public class Audience.PlaybackManager : Object {
     public signal void set_subtitle (string uri);
     public signal void stop ();
 
-    private static PlaybackManager? _instance;
-    public static PlaybackManager get_default () {
-        if (_instance == null) {
-            _instance = new PlaybackManager ();
-        }
-
-        return _instance;
+    private static GLib.Once<PlaybackManager> instance;
+    public static unowned PlaybackManager get_default () {
+        return instance.once (() => { return new PlaybackManager (); });
     }
 
     private PlaybackManager () {}

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -4,10 +4,10 @@
  */
 
 public class Audience.PlaybackManager : Object {
-    public signal void item_added ();
     public signal bool next ();
     public signal File? get_first_item ();
     public signal void clear_playlist (bool should_stop = true);
+    public signal void item_added ();
     public signal void play (File file);
     public signal void previous ();
     public signal void queue_file (File file);

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -8,6 +8,7 @@ public class Audience.PlaybackManager : Object {
     public signal void stop ();
     public signal void next ();
     public signal void previous ();
+    public signal void set_subtitle (string uri);
 
     private static PlaybackManager? _instance;
     public static PlaybackManager get_default () {

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -109,8 +109,8 @@ public class Audience.EpisodesPage : Gtk.Grid {
         if (video.video_file.query_exists ()) {
             string uri = video.video_file.get_uri ();
             bool from_beginning = uri != settings.get_string ("current-video");
+            PlaybackManager.get_default ().clear_playlist ();
             var window = App.get_instance ().mainwindow;// Clean playlist
-            window.clear_playlist ();
             window.add_to_playlist (uri, false);
             window.play_file (uri, Window.NavigationPage.EPISODES, from_beginning);
             if (window.autoqueue_next_active ()) {

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -112,10 +112,11 @@ public class Audience.EpisodesPage : Gtk.Grid {
 
             var playback_manager = PlaybackManager.get_default ();
             playback_manager.clear_playlist ();
+            playback_manager.append_to_playlist (video.video_file);
 
             var window = App.get_instance ().mainwindow;
-            window.add_to_playlist (uri, false);
             window.play_file (uri, Window.NavigationPage.EPISODES, from_beginning);
+
             if (window.autoqueue_next_active ()) {
                 // Add next from the current view to the queue
                 int played_index = shown_episodes.index_of (video);

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -109,15 +109,18 @@ public class Audience.EpisodesPage : Gtk.Grid {
         if (video.video_file.query_exists ()) {
             string uri = video.video_file.get_uri ();
             bool from_beginning = uri != settings.get_string ("current-video");
-            PlaybackManager.get_default ().clear_playlist ();
-            var window = App.get_instance ().mainwindow;// Clean playlist
+
+            var playback_manager = PlaybackManager.get_default ();
+            playback_manager.clear_playlist ();
+
+            var window = App.get_instance ().mainwindow;
             window.add_to_playlist (uri, false);
             window.play_file (uri, Window.NavigationPage.EPISODES, from_beginning);
             if (window.autoqueue_next_active ()) {
                 // Add next from the current view to the queue
                 int played_index = shown_episodes.index_of (video);
                 foreach (Audience.Objects.Video episode in shown_episodes.slice (played_index, shown_episodes.size)) {
-                    PlaybackManager.get_default ().append_to_playlist (episode.video_file);
+                    playback_manager.append_to_playlist (episode.video_file);
                 }
             }
         }

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -117,7 +117,7 @@ public class Audience.EpisodesPage : Gtk.Grid {
                 // Add next from the current view to the queue
                 int played_index = shown_episodes.index_of (video);
                 foreach (Audience.Objects.Video episode in shown_episodes.slice (played_index, shown_episodes.size)) {
-                    window.append_to_playlist (episode.video_file);
+                    PlaybackManager.get_default ().append_to_playlist (episode.video_file);
                 }
             }
         }

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -96,8 +96,13 @@ public class Audience.LibraryPage : Gtk.Stack {
             bool playback_complete = settings.get_double ("last-stopped") == 0.0;
             bool from_beginning = !same_video || playback_complete;
 
+            if (from_beginning) {
+                PlaybackManager.get_default ().clear_playlist ();
+            }
+
+            PlaybackManager.get_default ().append_to_playlist (File.new_for_uri (uri));
+
             var window = (Audience.Window) ((Gtk.Application) Application.get_default ()).active_window;
-            window.add_to_playlist (uri, !from_beginning);
             window.play_file (uri, Window.NavigationPage.LIBRARY, from_beginning);
         } else {
             last_filter = query;

--- a/src/Widgets/Player/BottomBar.vala
+++ b/src/Widgets/Player/BottomBar.vala
@@ -112,7 +112,7 @@ public class Audience.Widgets.BottomBar : Gtk.Revealer {
             return false;
         });
 
-        playlist_popover.playlist.item_added.connect (() => {
+        PlaybackManager.get_default ().item_added.connect (() => {
             playlist_item_added ();
         });
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -216,12 +216,9 @@ namespace Audience {
                 });
             });
 
-            //playlist wants us to open a file
-            PlaybackManager.get_default ().play.connect ((file) => {
-                ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file.get_uri ()) });
-            });
+            var playback_manager = PlaybackManager.get_default ();
 
-            PlaybackManager.get_default ().stop.connect (() => {
+            playback_manager.stop.connect (() => {
                 settings.set_double ("last-stopped", 0);
                 settings.set_strv ("last-played-videos", {});
                 settings.set_string ("current-video", "");
@@ -235,6 +232,8 @@ namespace Audience {
                     ended ();
                 }
             });
+
+            playback_manager.set_subtitle.connect (set_subtitle);
 
             bottom_bar.notify["child-revealed"].connect (() => {
                 if (bottom_bar.child_revealed == true) {

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -342,7 +342,7 @@ namespace Audience {
             if (is_subtitle (file.get_uri ())) {
                 set_subtitle (file.get_uri ());
             } else {
-                bottom_bar.playlist_popover.playlist.add_item (file);
+                PlaybackManager.get_default ().queue_file (file);
             }
         }
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -206,8 +206,8 @@ namespace Audience {
                     playback.progress = 0;
                     if (!playback_manager.next ()) {
                         if (bottom_bar.repeat) {
-                            string file = bottom_bar.playlist_popover.playlist.get_first_item ().get_uri ();
-                            ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file) });
+                            var file = playback_manager.get_first_item ();
+                            ((Audience.Window) App.get_instance ().active_window).open_files ({ file });
                         } else {
                             playback.playing = false;
                             settings.set_double ("last-stopped", 0);
@@ -303,9 +303,8 @@ namespace Audience {
                 debug (e.message);
             }
 
-            bottom_bar.playlist_popover.playlist.set_current (uri);
+            PlaybackManager.get_default ().set_current (uri);
             playback.uri = uri;
-
 
             App.get_instance ().active_window.title = get_title (uri);
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -217,11 +217,11 @@ namespace Audience {
             });
 
             //playlist wants us to open a file
-            get_playlist_widget ().play.connect ((file) => {
+            PlaybackManager.get_default ().play.connect ((file) => {
                 ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file.get_uri ()) });
             });
 
-            get_playlist_widget ().stop_video.connect (() => {
+            PlaybackManager.get_default ().stop.connect (() => {
                 settings.set_double ("last-stopped", 0);
                 settings.set_strv ("last-played-videos", {});
                 settings.set_string ("current-video", "");

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -338,14 +338,6 @@ namespace Audience {
             return playback.progress;
         }
 
-        public void append_to_playlist (File file) {
-            if (is_subtitle (file.get_uri ())) {
-                set_subtitle (file.get_uri ());
-            } else {
-                PlaybackManager.get_default ().queue_file (file);
-            }
-        }
-
         public void next_audio () {
             bottom_bar.preferences_popover.next_audio ();
         }
@@ -394,22 +386,8 @@ namespace Audience {
             return "";
         }
 
-        private bool is_subtitle (string uri) {
-            if (uri.length < 4 || uri.get_char (uri.length - 4) != '.') {
-                return false;
-            }
-
-            foreach (string ext in SUBTITLE_EXTENSIONS) {
-                if (uri.down ().has_suffix (ext)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
         private ulong ready_handler_id = 0;
-        public void set_subtitle (string uri) {
+        private void set_subtitle (string uri) {
             var progress = playback.progress;
             var is_playing = playback.playing;
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -234,11 +234,15 @@ namespace Audience {
                 }
             });
 
-            playback_manager.set_subtitle.connect (set_subtitle);
+            playback_manager.notify["subtitle-uri"].connect (() => {
+                set_subtitle (playback_manager.subtitle_uri);
+            });
 
             /* playback.subtitle_uri does not seem to notify so connect directly to the pipeline */
             pipeline.notify["suburi"].connect (() => {
-                playback_manager.subtitle_uri = playback.subtitle_uri;
+                if (playback_manager.subtitle_uri != playback.subtitle_uri) {
+                    playback_manager.subtitle_uri = playback.subtitle_uri;
+                }
             });
 
             bottom_bar.notify["child-revealed"].connect (() => {

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -339,14 +339,6 @@ namespace Audience {
             return playback.progress;
         }
 
-        public void next_audio () {
-            bottom_bar.preferences_popover.next_audio ();
-        }
-
-        public void next_text () {
-            bottom_bar.preferences_popover.next_text ();
-        }
-
         public void seek_jump_seconds (int seconds) {
             var duration = playback.duration;
             var progress = playback.progress;

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -190,7 +190,7 @@ namespace Audience {
                     settings.set_double ("last-stopped", playback.progress);
                 }
 
-                get_playlist_widget ().save_playlist ();
+                bottom_bar.playlist_popover.playlist.save_playlist ();
 
                 if (inhibit_token != 0) {
                     ((Gtk.Application) GLib.Application.get_default ()).uninhibit (inhibit_token);
@@ -202,9 +202,9 @@ namespace Audience {
             playback.eos.connect (() => {
                 Idle.add (() => {
                     playback.progress = 0;
-                    if (!get_playlist_widget ().next ()) {
+                    if (!bottom_bar.playlist_popover.playlist.next ()) {
                         if (bottom_bar.repeat) {
-                            string file = get_playlist_widget ().get_first_item ().get_uri ();
+                            string file = bottom_bar.playlist_popover.playlist.get_first_item ().get_uri ();
                             ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file) });
                         } else {
                             playback.playing = false;
@@ -291,7 +291,7 @@ namespace Audience {
                     unsupported_file_dialog.response.connect (type => {
                         if (type == Gtk.ResponseType.CANCEL) {
                             // Play next video if available or else go to welcome page
-                            if (!get_playlist_widget ().next ()) {
+                            if (!bottom_bar.playlist_popover.playlist.next ()) {
                                 ended ();
                             }
                         }
@@ -303,7 +303,7 @@ namespace Audience {
                 debug (e.message);
             }
 
-            get_playlist_widget ().set_current (uri);
+            bottom_bar.playlist_popover.playlist.set_current (uri);
             playback.uri = uri;
 
 
@@ -343,7 +343,7 @@ namespace Audience {
             if (is_subtitle (file.get_uri ())) {
                 set_subtitle (file.get_uri ());
             } else {
-                get_playlist_widget ().add_item (file);
+                bottom_bar.playlist_popover.playlist.add_item (file);
             }
         }
 
@@ -361,10 +361,6 @@ namespace Audience {
             var new_progress = ((duration * progress) + (double)seconds) / duration;
             playback.progress = new_progress.clamp (0.0, 1.0);
             bottom_bar.reveal_control ();
-        }
-
-        private Widgets.Playlist get_playlist_widget () {
-            return bottom_bar.playlist_popover.playlist;
         }
 
         public void hide_popovers () {

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -190,7 +190,7 @@ namespace Audience {
                     settings.set_double ("last-stopped", playback.progress);
                 }
 
-                bottom_bar.playlist_popover.playlist.save_playlist ();
+                PlaybackManager.get_default ().save_playlist ();
 
                 if (inhibit_token != 0) {
                     ((Gtk.Application) GLib.Application.get_default ()).uninhibit (inhibit_token);

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -363,7 +363,7 @@ namespace Audience {
             bottom_bar.reveal_control ();
         }
 
-        public Widgets.Playlist get_playlist_widget () {
+        private Widgets.Playlist get_playlist_widget () {
             return bottom_bar.playlist_popover.playlist;
         }
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -180,6 +180,8 @@ namespace Audience {
                 return update_pointer_position (event.y, allocation.height);
             });
 
+            var playback_manager = PlaybackManager.get_default ();
+
             destroy.connect (() => {
                 // FIXME:should find better way to decide if its end of playlist
                 if (playback.progress > 0.99) {
@@ -190,7 +192,7 @@ namespace Audience {
                     settings.set_double ("last-stopped", playback.progress);
                 }
 
-                PlaybackManager.get_default ().save_playlist ();
+                playback_manager.save_playlist ();
 
                 if (inhibit_token != 0) {
                     ((Gtk.Application) GLib.Application.get_default ()).uninhibit (inhibit_token);
@@ -202,7 +204,7 @@ namespace Audience {
             playback.eos.connect (() => {
                 Idle.add (() => {
                     playback.progress = 0;
-                    if (!bottom_bar.playlist_popover.playlist.next ()) {
+                    if (!playback_manager.next ()) {
                         if (bottom_bar.repeat) {
                             string file = bottom_bar.playlist_popover.playlist.get_first_item ().get_uri ();
                             ((Audience.Window) App.get_instance ().active_window).open_files ({ File.new_for_uri (file) });
@@ -215,8 +217,6 @@ namespace Audience {
                     return false;
                 });
             });
-
-            var playback_manager = PlaybackManager.get_default ();
 
             playback_manager.stop.connect (() => {
                 settings.set_double ("last-stopped", 0);
@@ -291,7 +291,7 @@ namespace Audience {
                     unsupported_file_dialog.response.connect (type => {
                         if (type == Gtk.ResponseType.CANCEL) {
                             // Play next video if available or else go to welcome page
-                            if (!bottom_bar.playlist_popover.playlist.next ()) {
+                            if (!PlaybackManager.get_default ().next ()) {
                                 ended ();
                             }
                         }

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -236,6 +236,11 @@ namespace Audience {
 
             playback_manager.set_subtitle.connect (set_subtitle);
 
+            /* playback.subtitle_uri does not seem to notify so connect directly to the pipeline */
+            pipeline.notify["suburi"].connect (() => {
+                playback_manager.subtitle_uri = playback.subtitle_uri;
+            });
+
             bottom_bar.notify["child-revealed"].connect (() => {
                 if (bottom_bar.child_revealed == true) {
                     ((Audience.Window) App.get_instance ().active_window).show_mouse_cursor ();

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -50,6 +50,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         var playback_manager = PlaybackManager.get_default ();
         playback_manager.next.connect (() => next ());
         playback_manager.previous.connect (previous);
+        playback_manager.clear_playlist.connect (clear_items);
     }
 
     ~Playlist () {
@@ -106,7 +107,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         item_added ();
     }
 
-    public void clear_items (bool should_stop = true) {
+    private void clear_items (bool should_stop = true) {
         current = 0;
         foreach (Gtk.Widget item in get_children ()) {
             remove (item);

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -48,17 +48,19 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
 
         var playback_manager = PlaybackManager.get_default ();
+        playback_manager.clear_playlist.connect (clear_items);
         playback_manager.next.connect (next);
         playback_manager.previous.connect (previous);
-        playback_manager.clear_playlist.connect (clear_items);
         playback_manager.save_playlist.connect (save_playlist);
+        playback_manager.set_current.connect (set_current);
+        playback_manager.get_first_item.connect (get_first_item);
     }
 
     ~Playlist () {
         save_playlist ();
     }
 
-    public bool next () {
+    private bool next () {
         var children = get_children ();
         current++;
         if (current >= children.length ()) {
@@ -119,7 +121,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
     }
 
-    public File? get_first_item () {
+    private File? get_first_item () {
         var children = get_children ();
         if (children.length () > 0) {
             var first_item = children.first ().data as PlaylistItem;
@@ -129,7 +131,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         return null;
     }
 
-    public void set_current (string current_file) {
+    private void set_current (string current_file) {
         int count = 0;
         int current_played = 0;
 

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -150,7 +150,8 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
     }
 
     private void save_playlist () {
-        if (Audience.App.get_instance ().mainwindow.is_privacy_mode_enabled ()) {
+        var privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
+        if (!privacy_settings.get_boolean ("remember-recent-files") || !privacy_settings.get_boolean ("remember-app-usage")) {
             return;
         }
 

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -19,9 +19,7 @@
 */
 
 public class Audience.Widgets.Playlist : Gtk.ListBox {
-    public signal void play (File path);
     public signal void item_added ();
-    public signal void stop_video ();
 
     private int current = 0;
 
@@ -36,7 +34,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
 
         row_activated.connect ((item) => {
             string filename = ((PlaylistItem)(item)).filename;
-            play (File.new_for_commandline_arg (filename));
+            PlaybackManager.get_default ().play (File.new_for_commandline_arg (filename));
         });
 
         Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
@@ -63,7 +61,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
 
         var next_item = (children.nth_data (current) as PlaylistItem);
-        play (File.new_for_commandline_arg (next_item.filename));
+        PlaybackManager.get_default ().play (File.new_for_commandline_arg (next_item.filename));
         return true;
     }
 
@@ -72,12 +70,12 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         current--;
         if (current < 0) {
             var first_item = children.first ().data as PlaylistItem;
-            play (File.new_for_commandline_arg (first_item.filename));
+            PlaybackManager.get_default ().play (File.new_for_commandline_arg (first_item.filename));
             return;
         }
 
         var next_item = (children.nth_data (current) as PlaylistItem);
-        play (File.new_for_commandline_arg (next_item.filename));
+        PlaybackManager.get_default ().play (File.new_for_commandline_arg (next_item.filename));
     }
 
     public void add_item (File path) {
@@ -111,7 +109,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
 
         if (should_stop) {
-            stop_video ();
+            PlaybackManager.get_default ().stop ();
         }
     }
 

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -19,8 +19,6 @@
 */
 
 public class Audience.Widgets.Playlist : Gtk.ListBox {
-    public signal void item_added ();
-
     private int current = 0;
 
     private const Gtk.TargetEntry[] TARGET_ENTRIES = {
@@ -49,11 +47,12 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
 
         var playback_manager = PlaybackManager.get_default ();
         playback_manager.clear_playlist.connect (clear_items);
+        playback_manager.get_first_item.connect (get_first_item);
         playback_manager.next.connect (next);
         playback_manager.previous.connect (previous);
+        playback_manager.queue_file.connect (add_item);
         playback_manager.save_playlist.connect (save_playlist);
         playback_manager.set_current.connect (set_current);
-        playback_manager.get_first_item.connect (get_first_item);
     }
 
     ~Playlist () {
@@ -86,7 +85,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         PlaybackManager.get_default ().play (File.new_for_commandline_arg (next_item.filename));
     }
 
-    public void add_item (File path) {
+    private void add_item (File path) {
         if (!path.query_exists ()) {
             return;
         }
@@ -107,7 +106,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
 
         var row = new PlaylistItem (Audience.get_title (path.get_basename ()), path.get_uri ());
         add (row);
-        item_added ();
+        PlaybackManager.get_default ().item_added ();
     }
 
     private void clear_items (bool should_stop = true) {

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -51,6 +51,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         playback_manager.next.connect (() => next ());
         playback_manager.previous.connect (previous);
         playback_manager.clear_playlist.connect (clear_items);
+        playback_manager.save_playlist.connect (save_playlist);
     }
 
     ~Playlist () {
@@ -157,7 +158,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         return (owned) list;
     }
 
-    public void save_playlist () {
+    private void save_playlist () {
         if (Audience.App.get_instance ().mainwindow.is_privacy_mode_enabled ()) {
             return;
         }
@@ -172,7 +173,6 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
 
         settings.set_strv ("last-played-videos", videos);
-
     }
 
     private void on_drag_data_received (Gdk.DragContext context, int x, int y,

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -149,28 +149,15 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         this.current = current_played;
     }
 
-    private List<string> get_all_items () {
-        var list = new List<string> ();
-        foreach (Gtk.Widget item in get_children ()) {
-            string name = ((PlaylistItem)(item)).filename;
-            list.append (name);
-        }
-
-        return (owned) list;
-    }
-
     private void save_playlist () {
         if (Audience.App.get_instance ().mainwindow.is_privacy_mode_enabled ()) {
             return;
         }
 
-        var list = get_all_items ();
-
-        uint i = 0;
-        var videos = new string[list.length ()];
-        foreach (var filename in list) {
-            videos[i] = filename;
-            i++;
+        string[] videos = {};
+        foreach (unowned var child in get_children ()) {
+            var filename = ((PlaylistItem) child).filename;
+            videos += filename;
         }
 
         settings.set_strv ("last-played-videos", videos);

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -46,6 +46,10 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
             }
             add_item (File.new_for_uri (settings.get_strv ("last-played-videos")[i]));
         }
+
+        var playback_manager = PlaybackManager.get_default ();
+        playback_manager.next.connect (() => next ());
+        playback_manager.previous.connect (previous);
     }
 
     ~Playlist () {
@@ -65,7 +69,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         return true;
     }
 
-    public void previous () {
+    private void previous () {
         var children = get_children ();
         current--;
         if (current < 0) {

--- a/src/Widgets/Player/Playlist.vala
+++ b/src/Widgets/Player/Playlist.vala
@@ -48,7 +48,7 @@ public class Audience.Widgets.Playlist : Gtk.ListBox {
         }
 
         var playback_manager = PlaybackManager.get_default ();
-        playback_manager.next.connect (() => next ());
+        playback_manager.next.connect (next);
         playback_manager.previous.connect (previous);
         playback_manager.clear_playlist.connect (clear_items);
         playback_manager.save_playlist.connect (save_playlist);

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -75,7 +75,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
         });
 
         clear_playlist_button.clicked.connect (() => {
-            playlist.clear_items ();
+            PlaybackManager.get_default ().clear_playlist ();
         });
 
         rep.toggled.connect ( () => {

--- a/src/Widgets/Player/PlaylistPopover.vala
+++ b/src/Widgets/Player/PlaylistPopover.vala
@@ -18,7 +18,6 @@
  */
 
 public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
-    public Playlist playlist { get; private set; }
     public Gtk.ToggleButton rep { get; private set; }
 
     private Gtk.Button dvd;
@@ -47,7 +46,7 @@ public class Audience.Widgets.PlaylistPopover : Gtk.Popover {
             propagate_natural_height = true
         };
 
-        playlist = new Playlist ();
+        var playlist = new Playlist ();
         playlist_scrolled.add (playlist);
 
         var grid = new Gtk.Grid () {

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -82,11 +82,8 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
             PlaybackManager.get_default ().set_subtitle (external_subtitle_file.get_uri ());
         });
 
-        unowned Gst.Pipeline pipeline = playback.get_pipeline () as Gst.Pipeline;
-        /* playback.subtitle_uri does not seem to notify so connect directly to the pipeline */
-        pipeline.notify["suburi"].connect (() => {
-            /* Easier to retrieve the uri from the playback than the pipeline */
-            external_subtitle_file.select_uri (playback.subtitle_uri ?? "");
+        playback_manager.notify["subtitle-uri"].connect (() => {
+            external_subtitle_file.select_uri (playback_manager.subtitle_uri ?? "");
         });
 
         subtitles.changed.connect (on_subtitles_changed);

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -79,7 +79,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         playback_manager.next_text.connect (next_text);
 
         external_subtitle_file.file_set.connect (() => {
-            PlaybackManager.get_default ().set_subtitle (external_subtitle_file.get_uri ());
+            PlaybackManager.get_default ().subtitle_uri = external_subtitle_file.get_uri ();
         });
 
         playback_manager.notify["subtitle-uri"].connect (() => {

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -75,7 +75,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         setupgrid.show_all ();
 
         external_subtitle_file.file_set.connect (() => {
-            ((Audience.Window)((Gtk.Application) Application.get_default ()).active_window).player_page.set_subtitle (external_subtitle_file.get_uri ());
+            PlaybackManager.get_default ().set_subtitle (external_subtitle_file.get_uri ());
         });
 
         unowned Gst.Pipeline pipeline = playback.get_pipeline () as Gst.Pipeline;

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -74,6 +74,10 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         setupgrid.attach (external_subtitle_file, 1, 3);
         setupgrid.show_all ();
 
+        var playback_manager = PlaybackManager.get_default ();
+        playback_manager.next_audio.connect (next_audio);
+        playback_manager.next_text.connect (next_text);
+
         external_subtitle_file.file_set.connect (() => {
             PlaybackManager.get_default ().set_subtitle (external_subtitle_file.get_uri ());
         });
@@ -183,7 +187,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         languages.changed.connect (on_languages_changed);
     }
 
-    public void next_audio () {
+    private void next_audio () {
         setup ();
         int count = languages.model.iter_n_children (null);
         if (count > 0) {
@@ -191,7 +195,7 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         }
     }
 
-    public void next_text () {
+    private void next_text () {
         setup ();
         int count = subtitles.model.iter_n_children (null);
         if (count > 0) {

--- a/src/Widgets/WelcomePage.vala
+++ b/src/Widgets/WelcomePage.vala
@@ -50,7 +50,8 @@ public class Audience.WelcomePage : Granite.Widgets.Welcome {
                     window.run_open_file (true);
                     break;
                 case 1:
-                    window.add_to_playlist (current_video, true);
+                    PlaybackManager.get_default ().append_to_playlist (File.new_for_uri (current_video));
+                    settings.set_string ("current-video", current_video);
                     window.resume_last_videos ();
                     break;
                 case 2:

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -485,11 +485,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
         file.destroy ();
     }
 
-    public bool is_privacy_mode_enabled () {
-        var privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
-        return !privacy_settings.get_boolean ("remember-recent-files") || !privacy_settings.get_boolean ("remember-app-usage");
-    }
-
     private async void read_first_disk () {
         var disk_manager = DiskManager.get_default ();
         if (disk_manager.get_volumes ().is_empty) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -30,8 +30,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
     private Gtk.Button navigation_button;
     private Gtk.SearchEntry search_entry;
     private WelcomePage welcome_page;
-
-    public PlayerPage player_page { get; private set; }
+    private PlayerPage player_page;
 
     public enum NavigationPage { WELCOME, LIBRARY, EPISODES }
 
@@ -241,6 +240,11 @@ public class Audience.Window : Gtk.ApplicationWindow {
             }
 
             return Gdk.EVENT_PROPAGATE;
+        });
+
+        //playlist wants us to open a file
+        PlaybackManager.get_default ().play.connect ((file) => {
+            open_files ({ File.new_for_uri (file.get_uri ()) });
         });
 
         window_state_event.connect ((e) => {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -406,7 +406,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
 
     public void open_files (File[] files, bool clear_playlist_items = false, bool force_play = true) {
         if (clear_playlist_items) {
-            clear_playlist (false);
+            PlaybackManager.get_default ().clear_playlist (false);
         }
 
         string[] videos = {};
@@ -453,7 +453,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
 
     public void add_to_playlist (string uri, bool preserve_playlist) {
         if (!preserve_playlist) {
-            clear_playlist ();
+            PlaybackManager.get_default ().clear_playlist ();
         }
 
         player_page.append_to_playlist (File.new_for_uri (uri));
@@ -535,8 +535,8 @@ public class Audience.Window : Gtk.ApplicationWindow {
         }
     }
 
-    public void clear_playlist (bool should_stop = true) {
-        player_page.get_playlist_widget ().clear_items (should_stop);
+    private void clear_playlist (bool should_stop = true) {
+
     }
 
     public void append_to_playlist (File file) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -413,11 +413,11 @@ public class Audience.Window : Gtk.ApplicationWindow {
         foreach (var file in files) {
             if (file.query_file_type (0) == FileType.DIRECTORY) {
                 Audience.recurse_over_dir (file, (file_ret) => {
-                    player_page.append_to_playlist (file);
+                    PlaybackManager.get_default ().append_to_playlist (file);
                     videos += file_ret.get_uri ();
                 });
             } else {
-                player_page.append_to_playlist (file);
+                PlaybackManager.get_default ().append_to_playlist (file);
                 videos += file.get_uri ();
             }
         }
@@ -456,7 +456,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
             PlaybackManager.get_default ().clear_playlist ();
         }
 
-        player_page.append_to_playlist (File.new_for_uri (uri));
+        PlaybackManager.get_default ().append_to_playlist (File.new_for_uri (uri));
         settings.set_string ("current-video", uri);
     }
 
@@ -533,10 +533,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
         if (is_maximized) {
             fullscreen ();
         }
-    }
-
-    public void append_to_playlist (File file) {
-        player_page.append_to_playlist (file);
     }
 
     private void update_navigation () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -451,15 +451,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
         deck.visible_child = library_page;
     }
 
-    public void add_to_playlist (string uri, bool preserve_playlist) {
-        if (!preserve_playlist) {
-            PlaybackManager.get_default ().clear_playlist ();
-        }
-
-        PlaybackManager.get_default ().append_to_playlist (File.new_for_uri (uri));
-        settings.set_string ("current-video", uri);
-    }
-
     public void run_open_file (bool clear_playlist = false, bool force_play = true) {
         var all_files_filter = new Gtk.FileFilter ();
         all_files_filter.set_filter_name (_("All files"));

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -355,9 +355,9 @@ public class Audience.Window : Gtk.ApplicationWindow {
                 var play_pause_action = Application.get_default ().lookup_action (Audience.App.ACTION_PLAY_PAUSE);
                 ((SimpleAction) play_pause_action).activate (null);
             } else if (match_keycode (Gdk.Key.a, keycode)) {
-                player_page.next_audio ();
+                PlaybackManager.get_default ().next_audio ();
             } else if (match_keycode (Gdk.Key.s, keycode)) {
-                player_page.next_text ();
+                PlaybackManager.get_default ().next_text ();
             }
 
             bool shift_pressed = Gdk.ModifierType.SHIFT_MASK in e.state;

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -535,10 +535,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
         }
     }
 
-    private void clear_playlist (bool should_stop = true) {
-
-    }
-
     public void append_to_playlist (File file) {
         player_page.append_to_playlist (file);
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,7 @@ executable(
     'DBus/MprisRoot.vala',
     'Services/DirectoryMonitoring.vala',
     'Services/LibraryManager.vala',
+    'Services/PlaybackManager.vala',
     'Services/Thumbnailer.vala',
     'Widgets/UnsupportedFileDialog.vala',
     'Widgets/WelcomePage.vala',


### PR DESCRIPTION
Currently things like playback state, actions, the queue, etc are all stored across different widget-based classes. It's a huge mess with classes having to reach across each other and keep track of their instances to do anything.

This does the least to create a PlaybackManager class with a single instance where we can eventually store the queue, take actions, etc in a way that doesn't depend on the UI and doesn't involve passing objects around between classes etc

It's obviously kind of garbage right now because it doesn't actually hold the queue or the playbin, but hopefully it makes sense how eventually we'll get there and how even just this stops some of the reaching into other classes. Especially some obviously ridiculous lines like:
`((Audience.Window)((Gtk.Application) Application.get_default ()).active_window).player_page.set_subtitle (external_subtitle_file.get_uri ());`