### PR TITLE
Use playbin with the gst gtk widget for playback

### DIFF
--- a/data/io.elementary.videos.gschema.xml
+++ b/data/io.elementary.videos.gschema.xml
@@ -15,7 +15,7 @@
             <summary>External subtitle file for the current video</summary>
             <description></description>
         </key>
-        <key name="last-stopped" type="d">
+        <key name="last-stopped" type="x">
             <default>0</default>
             <summary>Last stopped time of last played video</summary>
             <description>Last stopped time of last played video</description>

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -45,7 +45,6 @@ public class Audience.PlaybackManager : Object {
 
         var bus = playbin.get_bus ();
         bus.add_signal_watch ();
-
         bus.message.connect (handle_bus_message);
 
         playbin.notify["suburi"].connect (() => {
@@ -76,10 +75,6 @@ public class Audience.PlaybackManager : Object {
         });
 
         Timeout.add (500, () => {
-            if (is_seeking) {
-                return Source.CONTINUE;
-            }
-
             int64 _position;
             if (playbin.query_position (Gst.Format.TIME, out _position)) {
                 position = _position;
@@ -147,7 +142,6 @@ public class Audience.PlaybackManager : Object {
                 }
 
                 if (playing) {
-                    get_audio_tracks ();
                     if (inhibit_token != 0) {
                         default_application.uninhibit (inhibit_token);
                     }
@@ -181,6 +175,7 @@ public class Audience.PlaybackManager : Object {
         debug ("Opening %s", uri);
 
         playbin.set_state (Gst.State.NULL);
+
         var file = File.new_for_uri (uri);
         try {
             var info = file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE + "," + GLib.FileAttribute.STANDARD_NAME, 0);

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -54,7 +54,7 @@ public class Audience.PlaybackManager : Object {
             }
         });
 
-        playbin.notify["current-uri"].connect (() => {
+        playbin.notify["uri"].connect (() => {
             uri_changed (playbin.uri);
         });
 

--- a/src/Services/PlaybackManager.vala
+++ b/src/Services/PlaybackManager.vala
@@ -123,10 +123,10 @@ public class Audience.PlaybackManager : Object {
 
             case STATE_CHANGED:
                 Gst.State old_state;
-            	Gst.State new_state;
-            	Gst.State pending_state;
+                Gst.State new_state;
+                Gst.State pending_state;
 
-            	message.parse_state_changed (out old_state, out new_state, out pending_state);
+                message.parse_state_changed (out old_state, out new_state, out pending_state);
 
                 playing = new_state == Gst.State.PLAYING;
 

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -93,7 +93,7 @@ public class Audience.LibraryPage : Gtk.Stack {
         if (selected.episodes.size == 1) {
             string uri = selected.episodes.first ().video_file.get_uri ();
             bool same_video = uri == settings.get_string ("current-video");
-            bool playback_complete = settings.get_double ("last-stopped") == 0.0;
+            bool playback_complete = settings.get_int64 ("last-stopped") == 0.0;
             bool from_beginning = !same_video || playback_complete;
 
             if (from_beginning) {

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -144,7 +144,11 @@ namespace Audience {
 
         public void seek_jump_seconds (int seconds) {
             var playback_manager = PlaybackManager.get_default ();
-            playback_manager.seek (playback_manager.position + (seconds * 1000000000));
+            int64 new_position = playback_manager.position + (int64)seconds * (int64)1000000000;
+            if (new_position < 0) {
+                new_position = 0;
+            }
+            playback_manager.seek (new_position);
             bottom_bar.reveal_control ();
         }
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -64,7 +64,8 @@ namespace Audience {
 
             unfullscreen_revealer = new Gtk.Revealer () {
                 transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
-                valign = START
+                valign = START,
+                halign = END
             };
             unfullscreen_revealer.add (unfullscreen_button);
             unfullscreen_revealer.show_all ();

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -184,7 +184,7 @@ namespace Audience {
 
         public void seek_jump_seconds (int seconds) {
             var playback_manager = PlaybackManager.get_default ();
-            playback_manager.position = playback_manager.position + (seconds * 1000000000);
+            playback_manager.seek (playback_manager.position + (seconds * 1000000000));
             bottom_bar.reveal_control ();
         }
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -27,12 +27,7 @@ namespace Audience {
 
     public class PlayerPage : Gtk.EventBox {
         private Audience.Widgets.BottomBar bottom_bar;
-        private GtkClutter.Actor bottom_actor;
-        private GtkClutter.Embed clutter;
-        private Clutter.Stage stage;
         private Gtk.Revealer unfullscreen_revealer;
-        private GtkClutter.Actor unfullscreen_actor;
-        private Clutter.Actor video_actor;
 
         private bool mouse_primary_down = false;
 
@@ -62,55 +57,66 @@ namespace Audience {
             events |= Gdk.EventMask.KEY_PRESS_MASK;
             events |= Gdk.EventMask.KEY_RELEASE_MASK;
 
-            clutter = new GtkClutter.Embed ();
-            stage = (Clutter.Stage)clutter.get_stage ();
-            stage.background_color = {0, 0, 0, 0};
+//             clutter = new GtkClutter.Embed ();
+//             stage = (Clutter.Stage)clutter.get_stage ();
+//             stage.background_color = {0, 0, 0, 0};
 
-            video_actor = new Clutter.Actor ();
-#if VALA_0_34
-            var aspect_ratio = new ClutterGst.Aspectratio ();
-#else
-            var aspect_ratio = ClutterGst.Aspectratio.@new ();
-#endif
-            ((ClutterGst.Aspectratio) aspect_ratio).paint_borders = false;
-            ((ClutterGst.Content) aspect_ratio).player = playback_manager.playback;
+//             video_actor = new Clutter.Actor ();
+// #if VALA_0_34
+//             var aspect_ratio = new ClutterGst.Aspectratio ();
+// #else
+//             var aspect_ratio = ClutterGst.Aspectratio.@new ();
+// #endif
+//             ((ClutterGst.Aspectratio) aspect_ratio).paint_borders = false;
+//             ((ClutterGst.Content) aspect_ratio).player = playback_manager.playback;
 
-            video_actor.content = aspect_ratio;
+//             video_actor.content = aspect_ratio;
 
-            video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
-            video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.HEIGHT, 0));
+//             video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
+//             video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.HEIGHT, 0));
 
-            Signal.connect (clutter, "button-press-event", (GLib.Callback) navigation_event, this);
-            Signal.connect (clutter, "button-release-event", (GLib.Callback) navigation_event, this);
-            Signal.connect (clutter, "key-press-event", (GLib.Callback) navigation_event, this);
-            Signal.connect (clutter, "key-release-event", (GLib.Callback) navigation_event, this);
-            Signal.connect (clutter, "motion-notify-event", (GLib.Callback) navigation_event, this);
+//             stage.add_child (video_actor);
 
-            stage.add_child (video_actor);
-
-            bottom_bar = new Widgets.BottomBar ();
+            bottom_bar = new Widgets.BottomBar () {
+                valign = END
+            };
 
             var unfullscreen_button = new Gtk.Button.from_icon_name ("view-restore-symbolic", Gtk.IconSize.BUTTON) {
                 tooltip_text = _("Unfullscreen")
             };
 
             unfullscreen_revealer = new Gtk.Revealer () {
-                transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN
+                transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+                valign = START
             };
             unfullscreen_revealer.add (unfullscreen_button);
             unfullscreen_revealer.show_all ();
 
-            bottom_actor = new GtkClutter.Actor.with_contents (bottom_bar);
-            bottom_actor.opacity = GLOBAL_OPACITY;
-            bottom_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
-            bottom_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 1));
-            stage.add_child (bottom_actor);
+            var overlay = new Gtk.Overlay () {
+                child = playback_manager.gst_video_widget
+            };
+            overlay.add_overlay (unfullscreen_revealer);
+            overlay.add_overlay (bottom_bar);
 
-            unfullscreen_actor = new GtkClutter.Actor.with_contents (unfullscreen_revealer);
-            unfullscreen_actor.opacity = GLOBAL_OPACITY;
-            unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.X_AXIS, 1));
-            unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 0));
-            stage.add_child (unfullscreen_actor);
+            add (overlay);
+
+            // Signal.connect (playback_manager.gst_video_widget, "button-press-event", (GLib.Callback) navigation_event, this);
+            // Signal.connect (playback_manager.gst_video_widget, "button-release-event", (GLib.Callback) navigation_event, this);
+            // Signal.connect (playback_manager.gst_video_widget, "key-press-event", (GLib.Callback) navigation_event, this);
+            // Signal.connect (playback_manager.gst_video_widget, "key-release-event", (GLib.Callback) navigation_event, this);
+            // Signal.connect (playback_manager.gst_video_widget, "motion-notify-event", (GLib.Callback) navigation_event, this);
+
+            // bottom_actor = new GtkClutter.Actor.with_contents (bottom_bar);
+            // bottom_actor.opacity = GLOBAL_OPACITY;
+            // bottom_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
+            // bottom_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 1));
+            // stage.add_child (bottom_actor);
+
+            // unfullscreen_actor = new GtkClutter.Actor.with_contents (unfullscreen_revealer);
+            // unfullscreen_actor.opacity = GLOBAL_OPACITY;
+            // unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.X_AXIS, 1));
+            // unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 0));
+            // stage.add_child (unfullscreen_actor);
 
             motion_notify_event.connect (event => {
                 if (mouse_primary_down) {
@@ -120,7 +126,7 @@ namespace Audience {
                 }
 
                 Gtk.Allocation allocation;
-                clutter.get_allocation (out allocation);
+                get_allocation (out allocation);
                 return update_pointer_position (event.y, allocation.height);
             });
 
@@ -154,7 +160,7 @@ namespace Audience {
 
             leave_notify_event.connect (event => {
                 Gtk.Allocation allocation;
-                clutter.get_allocation (out allocation);
+                get_allocation (out allocation);
 
                 if (event.x == event.window.get_width ()) {
                     return update_pointer_position (event.window.get_height (), allocation.height);
@@ -173,26 +179,22 @@ namespace Audience {
                 }
             });
 
-            add (clutter);
             show_all ();
         }
 
         public void seek_jump_seconds (int seconds) {
             var playback_manager = PlaybackManager.get_default ();
-            var duration = playback_manager.get_duration ();
-            var progress = playback_manager.get_progress ();
-            var new_progress = ((duration * progress) + (double)seconds) / duration;
-            playback_manager.set_progress (new_progress.clamp (0.0, 1.0));
+            playback_manager.position = playback_manager.position + (seconds * 1000000000);
             bottom_bar.reveal_control ();
         }
 
         public void hide_popovers () {
             bottom_bar.playlist_popover.popdown ();
 
-            var popover = bottom_bar.time_widget.preview_popover;
-            if (popover != null) {
-                popover.schedule_hide ();
-            }
+            // var popover = bottom_bar.time_widget.preview_popover;
+            // if (popover != null) {
+            //     popover.schedule_hide ();
+            // }
         }
 
         private bool update_pointer_position (double y, int window_height) {
@@ -203,42 +205,42 @@ namespace Audience {
             return false;
         }
 
-        [CCode (instance_pos = -1)]
-        private bool navigation_event (GtkClutter.Embed embed, Clutter.Event event) {
-            var video_sink = PlaybackManager.get_default ().playback.get_video_sink ();
-            var frame = video_sink.get_frame ();
-            if (frame == null) {
-                return true;
-            }
+        // [CCode (instance_pos = -1)]
+        // private bool navigation_event (GtkClutter.Embed embed, Clutter.Event event) {
+        //     var video_sink = PlaybackManager.get_default ().playback.get_video_sink ();
+        //     var frame = video_sink.get_frame ();
+        //     if (frame == null) {
+        //         return true;
+        //     }
 
-            float x, y;
-            event.get_coords (out x, out y);
-            // Transform event coordinates into the actor's coordinates
-            video_actor.transform_stage_point (x, y, out x, out y);
-            float actor_width, actor_height;
-            video_actor.get_size (out actor_width, out actor_height);
+        //     float x, y;
+        //     event.get_coords (out x, out y);
+        //     // Transform event coordinates into the actor's coordinates
+        //     video_actor.transform_stage_point (x, y, out x, out y);
+        //     float actor_width, actor_height;
+        //     video_actor.get_size (out actor_width, out actor_height);
 
-            /* Convert event's coordinates into the frame's coordinates. */
-            x = x * frame.resolution.width / actor_width;
-            y = y * frame.resolution.height / actor_height;
+        //     /* Convert event's coordinates into the frame's coordinates. */
+        //     x = x * frame.resolution.width / actor_width;
+        //     y = y * frame.resolution.height / actor_height;
 
-            switch (event.type) {
-                case Clutter.EventType.MOTION:
-                    ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-move", 0, x, y);
-                    break;
-                case Clutter.EventType.BUTTON_PRESS:
-                    ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-button-press", (int)event.button.button, x, y);
-                    break;
-                case Clutter.EventType.KEY_PRESS:
-                    warning (X.keysym_to_string (event.key.keyval));
-                    ((Gst.Video.Navigation) video_sink).send_key_event ("key-press", X.keysym_to_string (event.key.keyval));
-                    break;
-                case Clutter.EventType.KEY_RELEASE:
-                    ((Gst.Video.Navigation) video_sink).send_key_event ("key-release", X.keysym_to_string (event.key.keyval));
-                    break;
-            }
+        //     switch (event.type) {
+        //         case Clutter.EventType.MOTION:
+        //             ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-move", 0, x, y);
+        //             break;
+        //         case Clutter.EventType.BUTTON_PRESS:
+        //             ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-button-press", (int)event.button.button, x, y);
+        //             break;
+        //         case Clutter.EventType.KEY_PRESS:
+        //             warning (X.keysym_to_string (event.key.keyval));
+        //             ((Gst.Video.Navigation) video_sink).send_key_event ("key-press", X.keysym_to_string (event.key.keyval));
+        //             break;
+        //         case Clutter.EventType.KEY_RELEASE:
+        //             ((Gst.Video.Navigation) video_sink).send_key_event ("key-release", X.keysym_to_string (event.key.keyval));
+        //             break;
+        //     }
 
-            return false;
-        }
+        //     return false;
+        // }
     }
 }

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -47,35 +47,12 @@ namespace Audience {
             }
         }
 
-        public PlayerPage () {
-        }
-
         construct {
             var playback_manager = PlaybackManager.get_default ();
 
             events |= Gdk.EventMask.POINTER_MOTION_MASK;
             events |= Gdk.EventMask.KEY_PRESS_MASK;
             events |= Gdk.EventMask.KEY_RELEASE_MASK;
-
-//             clutter = new GtkClutter.Embed ();
-//             stage = (Clutter.Stage)clutter.get_stage ();
-//             stage.background_color = {0, 0, 0, 0};
-
-//             video_actor = new Clutter.Actor ();
-// #if VALA_0_34
-//             var aspect_ratio = new ClutterGst.Aspectratio ();
-// #else
-//             var aspect_ratio = ClutterGst.Aspectratio.@new ();
-// #endif
-//             ((ClutterGst.Aspectratio) aspect_ratio).paint_borders = false;
-//             ((ClutterGst.Content) aspect_ratio).player = playback_manager.playback;
-
-//             video_actor.content = aspect_ratio;
-
-//             video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
-//             video_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.HEIGHT, 0));
-
-//             stage.add_child (video_actor);
 
             bottom_bar = new Widgets.BottomBar () {
                 valign = END
@@ -99,24 +76,6 @@ namespace Audience {
             overlay.add_overlay (bottom_bar);
 
             add (overlay);
-
-            // Signal.connect (playback_manager.gst_video_widget, "button-press-event", (GLib.Callback) navigation_event, this);
-            // Signal.connect (playback_manager.gst_video_widget, "button-release-event", (GLib.Callback) navigation_event, this);
-            // Signal.connect (playback_manager.gst_video_widget, "key-press-event", (GLib.Callback) navigation_event, this);
-            // Signal.connect (playback_manager.gst_video_widget, "key-release-event", (GLib.Callback) navigation_event, this);
-            // Signal.connect (playback_manager.gst_video_widget, "motion-notify-event", (GLib.Callback) navigation_event, this);
-
-            // bottom_actor = new GtkClutter.Actor.with_contents (bottom_bar);
-            // bottom_actor.opacity = GLOBAL_OPACITY;
-            // bottom_actor.add_constraint (new Clutter.BindConstraint (stage, Clutter.BindCoordinate.WIDTH, 0));
-            // bottom_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 1));
-            // stage.add_child (bottom_actor);
-
-            // unfullscreen_actor = new GtkClutter.Actor.with_contents (unfullscreen_revealer);
-            // unfullscreen_actor.opacity = GLOBAL_OPACITY;
-            // unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.X_AXIS, 1));
-            // unfullscreen_actor.add_constraint (new Clutter.AlignConstraint (stage, Clutter.AlignAxis.Y_AXIS, 0));
-            // stage.add_child (unfullscreen_actor);
 
             motion_notify_event.connect (event => {
                 if (mouse_primary_down) {
@@ -191,10 +150,10 @@ namespace Audience {
         public void hide_popovers () {
             bottom_bar.playlist_popover.popdown ();
 
-            // var popover = bottom_bar.time_widget.preview_popover;
-            // if (popover != null) {
-            //     popover.schedule_hide ();
-            // }
+            var popover = bottom_bar.time_widget.preview_popover;
+            if (popover != null) {
+                popover.schedule_hide ();
+            }
         }
 
         private bool update_pointer_position (double y, int window_height) {
@@ -204,43 +163,5 @@ namespace Audience {
 
             return false;
         }
-
-        // [CCode (instance_pos = -1)]
-        // private bool navigation_event (GtkClutter.Embed embed, Clutter.Event event) {
-        //     var video_sink = PlaybackManager.get_default ().playback.get_video_sink ();
-        //     var frame = video_sink.get_frame ();
-        //     if (frame == null) {
-        //         return true;
-        //     }
-
-        //     float x, y;
-        //     event.get_coords (out x, out y);
-        //     // Transform event coordinates into the actor's coordinates
-        //     video_actor.transform_stage_point (x, y, out x, out y);
-        //     float actor_width, actor_height;
-        //     video_actor.get_size (out actor_width, out actor_height);
-
-        //     /* Convert event's coordinates into the frame's coordinates. */
-        //     x = x * frame.resolution.width / actor_width;
-        //     y = y * frame.resolution.height / actor_height;
-
-        //     switch (event.type) {
-        //         case Clutter.EventType.MOTION:
-        //             ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-move", 0, x, y);
-        //             break;
-        //         case Clutter.EventType.BUTTON_PRESS:
-        //             ((Gst.Video.Navigation) video_sink).send_mouse_event ("mouse-button-press", (int)event.button.button, x, y);
-        //             break;
-        //         case Clutter.EventType.KEY_PRESS:
-        //             warning (X.keysym_to_string (event.key.keyval));
-        //             ((Gst.Video.Navigation) video_sink).send_key_event ("key-press", X.keysym_to_string (event.key.keyval));
-        //             break;
-        //         case Clutter.EventType.KEY_RELEASE:
-        //             ((Gst.Video.Navigation) video_sink).send_key_event ("key-release", X.keysym_to_string (event.key.keyval));
-        //             break;
-        //     }
-
-        //     return false;
-        // }
     }
 }

--- a/src/Widgets/Player/SeekBar.vala
+++ b/src/Widgets/Player/SeekBar.vala
@@ -115,9 +115,9 @@ public class Videos.SeekBar : Gtk.Box {
             // This isn't necessarily a bug with the slider widget,
             // but this is the desired behavior for this slider in
             // the video player
-            scale.set_value (event.x / scale.get_range_rect ().width);
+            scale.set_value (event.x / scale.get_range_rect ().width * playback_duration);
 
-            playback_manager.position = (int64)scale.get_value ();
+            playback_manager.seek ((int64)scale.get_value ());
             return false;
         });
     }

--- a/src/Widgets/Player/SettingsPopover.vala
+++ b/src/Widgets/Player/SettingsPopover.vala
@@ -160,14 +160,13 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
 
         var playback_manager = PlaybackManager.get_default ();
 
-        var languages_names = get_audio_track_names ();
         uint track = 1;
-        playback_manager.get_audio_tracks ().foreach ((lang) => {
-            var audio_stream_lang = languages_names.nth_data (track - 1);
+        playback_manager.get_audio_tracks ().foreach ((language_code) => {
+            var audio_stream_lang = Gst.Tag.get_language_name (language_code);
             if (audio_stream_lang != null) {
-                languages.append (lang, audio_stream_lang);
+                languages.append (language_code, audio_stream_lang);
             } else {
-                languages.append (lang, _("Track %u").printf (track));
+                languages.append (language_code, _("Track %u").printf (track));
             }
             track++;
         });
@@ -201,29 +200,5 @@ public class Audience.Widgets.SettingsPopover : Gtk.Popover {
         if (count > 0) {
             subtitles.active = (subtitles.active + 1) % count;
         }
-    }
-
-    private GLib.List<string?> get_audio_track_names () {
-        GLib.List<string?> audio_languages = null;
-
-        var discoverer_info = Audience.get_discoverer_info (PlaybackManager.get_default ().get_uri ());
-        if (discoverer_info != null) {
-            var audio_streams = discoverer_info.get_audio_streams ();
-
-            foreach (var audio_stream in audio_streams) {
-                unowned string language_code = ((Gst.PbUtils.DiscovererAudioInfo)(audio_stream)).get_language ();
-                if (language_code != null) {
-                    var language_name = Gst.Tag.get_language_name (language_code);
-                    audio_languages.append (language_name);
-                } else {
-                    audio_languages.append (null);
-                }
-            }
-
-            // Both ClutterGst and DiscovererAudioInfo return tracks in opposite order.
-            audio_languages.reverse ();
-        }
-
-        return audio_languages;
     }
 }

--- a/src/Widgets/WelcomePage.vala
+++ b/src/Widgets/WelcomePage.vala
@@ -105,7 +105,7 @@ public class Audience.WelcomePage : Granite.Widgets.Welcome {
     }
 
     private void update_replay_title () {
-        if (settings.get_double ("last-stopped") == 0.0) {
+        if (settings.get_int64 ("last-stopped") == 0.0) {
             replay_button.title = _("Replay last video");
             replay_button.icon.icon_name = ("media-playlist-repeat");
         } else {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -525,9 +525,9 @@ public class Audience.Window : Gtk.ApplicationWindow {
     }
 
     private void update_navigation () {
-        double progress = PlaybackManager.get_default ().get_progress ();
-        if (progress > 0) {
-            settings.set_double ("last-stopped", progress);
+        int64 position = PlaybackManager.get_default ().position;
+        if (position > 0) {
+            settings.set_int64 ("last-stopped", position);
         }
 
         var play_pause_action = Application.get_default ().lookup_action (Audience.App.ACTION_PLAY_PAUSE);


### PR DESCRIPTION
- Use the gst provided GTK widget for playback on the PlayerPage and the playbin for the backend and as pipeline
- Preparation for #334 
- Continuation of #261 

Should be working needs some testing though. 
It sometimes crashes when resuming a video. I tracked the issue down to PreviewPopover and can confirm it is happening in master too. If you want to test without this crash comment [this line](https://github.com/elementary/videos/blob/6cfb084829970ea7f8574492fcc028c5e2991079/src/Widgets/Player/SeekBar.vala#L70C23-L70C23) (and ignore the warnings).