### PR TITLE
Separate headerbars with deck pages

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -63,6 +63,12 @@ namespace Audience {
             return app;
         }
 
+        public override void startup () {
+            base.startup ();
+
+            Hdy.init ();
+        }
+
         public override void activate () {
             if (mainwindow == null) {
                 add_action_entries (ACTION_ENTRIES, this);

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -121,6 +121,10 @@ public class Audience.EpisodesPage : Gtk.Box {
         });
     }
 
+    public void search () {
+        search_entry.grab_focus ();
+    }
+
     public void set_episodes_items (Gee.ArrayList<Audience.Objects.Video> episodes) {
         view_episodes.forall ((item) => {
             item.dispose ();

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -42,10 +42,14 @@ public class Audience.EpisodesPage : Gtk.Box {
             valign = CENTER
         };
 
-        var autoqueue_next = new Granite.ModeSwitch.from_icon_name ("media-playlist-repeat-one-symbolic", "media-playlist-consecutive-symbolic");
-        autoqueue_next.primary_icon_tooltip_text = _("Play one video");
-        autoqueue_next.secondary_icon_tooltip_text = _("Automatically play next videos");
-        autoqueue_next.valign = Gtk.Align.CENTER;
+        var autoqueue_next = new Granite.ModeSwitch.from_icon_name (
+            "media-playlist-repeat-one-symbolic",
+            "media-playlist-consecutive-symbolic"
+        ) {
+            primary_icon_tooltip_text = _("Play one video"),
+            secondary_icon_tooltip_text = _("Automatically play next videos"),
+            valign = Gtk.Align.CENTER
+        };
         settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
 
         header_bar = new Hdy.HeaderBar () {
@@ -57,7 +61,9 @@ public class Audience.EpisodesPage : Gtk.Box {
         header_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         poster = new Gtk.Image () {
-            margin = 24,
+            margin_top = 24,
+            margin_bottom = 24,
+            margin_start = 24,
             margin_end = 0,
             valign = Gtk.Align.START
         };
@@ -65,7 +71,10 @@ public class Audience.EpisodesPage : Gtk.Box {
 
         view_episodes = new Gtk.FlowBox () {
             homogeneous = true,
-            margin = 24,
+            margin_top = 24,
+            margin_bottom = 24,
+            margin_start = 24,
+            margin_end = 24,
             max_children_per_line = 1,
             selection_mode = Gtk.SelectionMode.NONE,
             valign = Gtk.Align.START
@@ -74,9 +83,10 @@ public class Audience.EpisodesPage : Gtk.Box {
         view_episodes.set_filter_func (episodes_filter_func);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null) {
-            expand = true
+            hexpand = true,
+            vexpand = true,
+            child = view_episodes
         };
-        scrolled_window.add (view_episodes);
 
         alert_view = new Granite.Widgets.AlertView (
             "",

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -54,23 +54,12 @@ public class Audience.LibraryPage : Gtk.Box {
             valign = CENTER
         };
 
-        var autoqueue_next = new Granite.ModeSwitch.from_icon_name (
-            "media-playlist-repeat-one-symbolic",
-            "media-playlist-consecutive-symbolic"
-        ) {
-            primary_icon_tooltip_text = _("Play one video"),
-            secondary_icon_tooltip_text = _("Automatically play next videos"),
-            valign = Gtk.Align.CENTER
-        };
-        settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
-
         var header_bar = new Hdy.HeaderBar () {
             show_close_button = true,
             title = _("Library")
         };
         header_bar.pack_start (navigation_button);
         header_bar.pack_end (search_entry);
-        header_bar.pack_end (autoqueue_next);
         header_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         view_movies = new Gtk.FlowBox () {

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -54,10 +54,14 @@ public class Audience.LibraryPage : Gtk.Box {
             valign = CENTER
         };
 
-        var autoqueue_next = new Granite.ModeSwitch.from_icon_name ("media-playlist-repeat-one-symbolic", "media-playlist-consecutive-symbolic");
-        autoqueue_next.primary_icon_tooltip_text = _("Play one video");
-        autoqueue_next.secondary_icon_tooltip_text = _("Automatically play next videos");
-        autoqueue_next.valign = Gtk.Align.CENTER;
+        var autoqueue_next = new Granite.ModeSwitch.from_icon_name (
+            "media-playlist-repeat-one-symbolic",
+            "media-playlist-consecutive-symbolic"
+        ) {
+            primary_icon_tooltip_text = _("Play one video"),
+            secondary_icon_tooltip_text = _("Automatically play next videos"),
+            valign = Gtk.Align.CENTER
+        };
         settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
 
         var header_bar = new Hdy.HeaderBar () {

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -137,6 +137,10 @@ public class Audience.LibraryPage : Gtk.Box {
         });
     }
 
+    public void search () {
+        search_entry.grab_focus ();
+    }
+
     private void play_video (Gtk.FlowBoxChild item) {
         var selected = (item as Audience.LibraryItem);
 

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -59,9 +59,6 @@ namespace Audience {
             }
         }
 
-        public PlayerPage () {
-        }
-
         construct {
             var playback_manager = PlaybackManager.get_default ();
 
@@ -70,10 +67,14 @@ namespace Audience {
             };
             navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-            var autoqueue_next = new Granite.ModeSwitch.from_icon_name ("media-playlist-repeat-one-symbolic", "media-playlist-consecutive-symbolic");
-            autoqueue_next.primary_icon_tooltip_text = _("Play one video");
-            autoqueue_next.secondary_icon_tooltip_text = _("Automatically play next videos");
-            autoqueue_next.valign = Gtk.Align.CENTER;
+            var autoqueue_next = new Granite.ModeSwitch.from_icon_name (
+                "media-playlist-repeat-one-symbolic",
+                "media-playlist-consecutive-symbolic"
+            ) {
+                primary_icon_tooltip_text = _("Play one video"),
+                secondary_icon_tooltip_text = _("Automatically play next videos"),
+                valign = Gtk.Align.CENTER
+            };
             settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
 
             header_bar = new Hdy.HeaderBar () {

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -103,7 +103,9 @@ namespace Audience {
             overlay.add_overlay (bottom_bar);
 
             var event_box = new Gtk.EventBox () {
-                child = overlay
+                child = overlay,
+                hexpand = true,
+                vexpand = true
             };
             event_box.events |= Gdk.EventMask.POINTER_MOTION_MASK;
             event_box.events |= Gdk.EventMask.KEY_PRESS_MASK;

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -62,22 +62,11 @@ namespace Audience {
             };
             navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
-            var autoqueue_next = new Granite.ModeSwitch.from_icon_name (
-                "media-playlist-repeat-one-symbolic",
-                "media-playlist-consecutive-symbolic"
-            ) {
-                primary_icon_tooltip_text = _("Play one video"),
-                secondary_icon_tooltip_text = _("Automatically play next videos"),
-                valign = Gtk.Align.CENTER
-            };
-            settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
-
             header_bar = new Hdy.HeaderBar () {
                 show_close_button = true,
                 title = _("Library")
             };
             header_bar.pack_start (navigation_button);
-            header_bar.pack_end (autoqueue_next);
             header_bar.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
             bottom_bar = new Widgets.BottomBar () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -199,7 +199,6 @@ public class Audience.Window : Hdy.ApplicationWindow {
         window_state_event.connect ((e) => {
             if (Gdk.WindowState.FULLSCREEN in e.changed_mask) {
                 player_page.fullscreened = Gdk.WindowState.FULLSCREEN in e.new_window_state;
-                // header.visible = !player_page.fullscreened;
 
                 if (!player_page.fullscreened) {
                     unmaximize ();

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -251,11 +251,13 @@ public class Audience.Window : Hdy.ApplicationWindow {
     }
 
     private void action_search () {
-        // if (search_entry.visible) {
-        //     search_entry.grab_focus ();
-        // } else {
-        //     Gdk.beep ();
-        // }
+        if (deck.visible_child == library_page) {
+            library_page.search ();
+        } else if (deck.visible_child == episodes_page) {
+            episodes_page.search ();
+        } else {
+            Gdk.beep ();
+        }
     }
 
     private void action_undo () {


### PR DESCRIPTION
- Moves the headerbar into the separate deck pages (PlayerPage, WelcomePage, LibraryPage, EpisodesPage) and makes it flat. This allows for smoother transitions between pages and keeps Videos more inline with the general OS look
- Use `Hdy.ApplicationWindow` for rounded corners
- Do some gtk4 prep while we're here
- The rounded corners are a bit buggy on the player, #335 might fix that though

Fixes #283 
Fixes #232

Screenshots:

![Screenshot from 2023-07-06 21 19 28](https://github.com/elementary/videos/assets/106322251/b2ed50e8-0762-42ca-95c8-41b12ada60a1)
![Screenshot from 2023-07-06 21 19 51](https://github.com/elementary/videos/assets/106322251/b78e1c74-9dfb-4177-8c5a-a8a81da66aba)
![Screenshot from 2023-07-06 21 19 56](https://github.com/elementary/videos/assets/106322251/fbc38eca-b89a-460c-ac9a-0f46eb59b288)
![Screenshot from 2023-07-06 21 20 10](https://github.com/elementary/videos/assets/106322251/1f4c2d84-a3f6-4545-b92a-c1d189815aca)
