### PR TITLE
EpisodesPage: Preparations for GTK4

### DIFF
--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -236,7 +236,7 @@ public class Audience.EpisodesPage : Gtk.Box {
         for (int i = 0; i < items.get_n_items (); i++) {
             var item = (LibraryItem)items.get_item (i);
             if (item.episodes.size == 0 || item.episodes.first ().video_file.get_path ().has_prefix (path)) {
-                item.dispose ();
+                items.remove (i);
             }
         }
 


### PR DESCRIPTION
- Use a `ListStore` with `bind_model` as `get_children` isn't available in GTK4
- No idea why but although documentation and a runtime warning say the ListBox filter_func won't work with a model, it actually does. Still with gtk4 we can/should wrap the ListStore in a FilterModel.