### PR TITLE
PreviewPopover: cleaner visual

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,0 +1,9 @@
+popover.preview contents {
+    background: black;
+    border: none;
+    box-shadow:
+        0 0 0 1px alpha(black, 0.05),
+        0 3px 4px alpha(black, 0.15),
+        0 3px 3px -3px alpha(black, 0.35);
+    margin: 0 1em;
+}

--- a/data/meson.build
+++ b/data/meson.build
@@ -36,3 +36,8 @@ i18n.merge_file(
     install: true,
     install_dir: get_option('datadir') / 'metainfo',
 )
+
+gresource = gnome.compile_resources(
+    'gresource',
+    'videos.gresource.xml'
+)

--- a/data/videos.gresource.xml
+++ b/data/videos.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/elementary/videos">
+    <file compressed="true">Application.css</file>
+  </gresource>
+</gresources>

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ config_file = configure_file(
     configuration: config_data
 )
 
+subdir('data')
 subdir('src')
 gnome.post_install(glib_compile_schemas: true)
-subdir('data')
 subdir('po')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -65,6 +65,8 @@ namespace Audience {
         public override void startup () {
             base.startup ();
 
+            Granite.init ();
+
             Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
         }
 

--- a/src/Widgets/Player/PreviewPopover.vala
+++ b/src/Widgets/Player/PreviewPopover.vala
@@ -37,8 +37,6 @@ public class Audience.Widgets.PreviewPopover : Gtk.Popover {
 
     private dynamic Gst.Element playbin;
     private Gdk.Paintable paintable;
-    private Adw.Clamp v_clamp;
-    private Adw.Clamp h_clamp;
 
     uint loop_timer_id = 0;
     uint show_timer_id = 0;
@@ -62,30 +60,22 @@ public class Audience.Widgets.PreviewPopover : Gtk.Popover {
 
         var picture = new Gtk.Picture.for_paintable (paintable) {
             hexpand = true,
-            vexpand = true,
-            margin_top = 3,
-            margin_bottom = 3,
-            margin_start = 3,
-            margin_end = 3
+            vexpand = true
         };
 
-        v_clamp = new Adw.Clamp () {
+        var v_clamp = new Adw.Clamp () {
             child = picture,
-            maximum_size = 200,
+            maximum_size = 128,
             orientation = VERTICAL
         };
 
-        h_clamp = new Adw.Clamp () {
-            child = v_clamp,
-            maximum_size = 200,
-            orientation = HORIZONTAL
-        };
-
         can_focus = false;
+        has_arrow = false;
         sensitive = false;
         autohide = false;
         position = TOP;
-        child = h_clamp;
+        child = v_clamp;
+        add_css_class ("preview");
 
         notify["playback-uri"].connect (() => {
             playbin.uri = playback_uri;
@@ -154,14 +144,13 @@ public class Audience.Widgets.PreviewPopover : Gtk.Popover {
         cancel_timer (ref hide_timer_id);
 
         show_timer_id = Timeout.add (300, () => {
-            var width = paintable.get_intrinsic_width ();
-            var height = paintable.get_intrinsic_height ();
-            if (width > 0 && height > 0) {
-                double diagonal = Math.sqrt ((width * width) + (height * height));
-                double k = 230 / diagonal; // for 16:9 ratio it produces width of ~200px
-                v_clamp.maximum_size = (int)(height * k);
-                h_clamp.maximum_size = (int)(width * k);
-            }
+            // var width = paintable.get_intrinsic_width ();
+            // var height = paintable.get_intrinsic_height ();
+            // if (width > 0 && height > 0) {
+            //     double diagonal = Math.sqrt ((width * width) + (height * height));
+            //     double k = 230 / diagonal; // for 16:9 ratio it produces width of ~200px
+            //     v_clamp.maximum_size = (int)(height * k);
+            // }
 
             popup ();
 

--- a/src/Widgets/Player/PreviewPopover.vala
+++ b/src/Widgets/Player/PreviewPopover.vala
@@ -144,14 +144,6 @@ public class Audience.Widgets.PreviewPopover : Gtk.Popover {
         cancel_timer (ref hide_timer_id);
 
         show_timer_id = Timeout.add (300, () => {
-            // var width = paintable.get_intrinsic_width ();
-            // var height = paintable.get_intrinsic_height ();
-            // if (width > 0 && height > 0) {
-            //     double diagonal = Math.sqrt ((width * width) + (height * height));
-            //     double k = 230 / diagonal; // for 16:9 ratio it produces width of ~200px
-            //     v_clamp.maximum_size = (int)(height * k);
-            // }
-
             popup ();
 
             if (req_position >= 0) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 executable(
     meson.project_name(),
     config_file,
+    gresource,
     'Application.vala',
     'Consts.vala',
     'DiskManager.vala',


### PR DESCRIPTION
Removes the borders and arrow and adds some css to make the preview popover super minimal and clean.

Got rid of the h clamp and the fancy aspect ratio stuff here since we shouldn't assume videos are 16:9 aspect ratio. If we just clamp vertically this works out well for ultrawide aspect ratios for example:

![Screenshot from 2023-08-20 13 19 30](https://github.com/elementary/videos/assets/7277719/784a5581-d1c4-4a40-aa8f-03e9a92ebecd)
