### PR TITLE
Remove automatic fullscreen

### DIFF
--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -28,26 +28,10 @@ namespace Audience {
     public class PlayerPage : Gtk.Box {
         private Gtk.HeaderBar header_bar;
         private Audience.Widgets.BottomBar bottom_bar;
-        private Gtk.Revealer unfullscreen_revealer;
+        private Gtk.Revealer windowcontrols_revealer;
         private Gtk.Revealer bottom_bar_revealer;
 
         private uint hiding_timer = 0;
-
-        private bool _fullscreened = false;
-        public bool fullscreened {
-            get {
-                return _fullscreened;
-            }
-            set {
-                _fullscreened = value;
-
-                header_bar.visible = !value;
-
-                if (bottom_bar_revealer.child_revealed) {
-                    reveal_control ();
-                }
-            }
-        }
 
         construct {
             var playback_manager = PlaybackManager.get_default ();
@@ -58,20 +42,14 @@ namespace Audience {
             navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
             header_bar = new Gtk.HeaderBar () {
-                show_title_buttons = true,
+                show_title_buttons = true
             };
             header_bar.pack_start (navigation_button);
-            header_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
 
-            var unfullscreen_button = new Gtk.Button.from_icon_name ("view-restore-symbolic") {
-                tooltip_text = _("Unfullscreen")
-            };
-
-            unfullscreen_revealer = new Gtk.Revealer () {
-                transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN,
+            windowcontrols_revealer = new Gtk.Revealer () {
+                transition_type = SLIDE_DOWN,
                 valign = START,
-                halign = END,
-                child = unfullscreen_button
+                child = header_bar
             };
 
             bottom_bar = new Widgets.BottomBar ();
@@ -92,11 +70,9 @@ namespace Audience {
             var overlay = new Gtk.Overlay () {
                 child = picture
             };
-            overlay.add_overlay (unfullscreen_revealer);
+            overlay.add_overlay (windowcontrols_revealer);
             overlay.add_overlay (bottom_bar_revealer);
 
-            orientation = VERTICAL;
-            append (header_bar);
             append (overlay);
 
             map.connect (() => {
@@ -139,10 +115,6 @@ namespace Audience {
                 var play_pause_action = Application.get_default ().lookup_action (Audience.App.ACTION_PLAY_PAUSE);
                 ((SimpleAction) play_pause_action).activate (null);
             });
-
-            unfullscreen_button.clicked.connect (() => {
-                ((Gtk.Window) get_root ()).unfullscreen ();
-            });
         }
 
         public void seek_jump_seconds (int seconds) {
@@ -166,10 +138,8 @@ namespace Audience {
             }
 
             bottom_bar_revealer.reveal_child = true;
+            windowcontrols_revealer.reveal_child = true;
             set_cursor (null);
-            if (fullscreened) {
-                unfullscreen_revealer.reveal_child = true;
-            }
 
             if (bottom_bar.should_stay_revealed) {
                 return;
@@ -178,7 +148,7 @@ namespace Audience {
             hiding_timer = Timeout.add (2000, () => {
                 hiding_timer = 0;
 
-                unfullscreen_revealer.reveal_child = false;
+                windowcontrols_revealer.reveal_child = false;
                 bottom_bar_revealer.reveal_child = false;
                 set_cursor (new Gdk.Cursor.from_name ("none", null));
 

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -159,20 +159,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
             app_notification.send_notification ();
         });
 
-        notify["maximized"].connect (() => {
-            if (leaflet.visible_child == player_page && maximized) {
-                fullscreen ();
-            }
-        });
-
-        notify["fullscreened"].connect (() => {
-            player_page.fullscreened = fullscreened;
-
-            if (!fullscreened) {
-                unmaximize ();
-            }
-        });
-
         var key_controller = new Gtk.EventControllerKey ();
         overlay.add_controller (key_controller);
         key_controller.key_released.connect (handle_key_press);
@@ -202,7 +188,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
 
     private void action_fullscreen () {
         if (leaflet.visible_child == player_page) {
-            if (player_page.fullscreened) {
+            if (fullscreened) {
                 unfullscreen ();
             } else {
                 fullscreen ();
@@ -271,7 +257,7 @@ public class Audience.Window : Gtk.ApplicationWindow {
             bool shift_pressed = SHIFT_MASK in state;
             switch (keyval) {
                 case Gdk.Key.Escape:
-                    if (player_page.fullscreened) {
+                    if (fullscreened) {
                         unfullscreen ();
                     } else {
                         destroy ();
@@ -416,7 +402,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
 
     private void on_player_ended () {
         leaflet.navigate (Adw.NavigationDirection.BACK);
-        unfullscreen ();
     }
 
     public void play_file (string uri, NavigationPage origin, bool from_beginning = true) {
@@ -424,9 +409,6 @@ public class Audience.Window : Gtk.ApplicationWindow {
         leaflet.visible_child = player_page;
 
         PlaybackManager.get_default ().play_file (uri, from_beginning);
-        if (maximized) {
-            fullscreen ();
-        }
     }
 
     public string get_adjacent_page_name () {


### PR DESCRIPTION
Closes #14 

Remove all the automatic fullscreen stuff and put the regular headerbar in the revealer on the playerpage. Fixes issues with not always having access to navigation or window controls. It's still possible to fullscreen manually with a keyboard shortcut