### PR TITLE
Headerbar improvements

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -1,0 +1,71 @@
+/*-
+ * Copyright 2023 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+public class Audience.HeaderBar : Gtk.Box {
+    public bool fullscreened {
+        set {
+            if (value) {
+                header_bar.set_decoration_layout ("close");
+            } else {
+                header_bar.set_decoration_layout (null);
+            }
+
+            unfullscreen_button.visible = value;
+        }
+    }
+
+    public bool flat { get; construct; }
+    public Gtk.HeaderBar header_bar { get; construct; }
+
+    private Gtk.Button unfullscreen_button;
+    private unowned GLib.Binding binding;
+
+    public HeaderBar (bool flat = true) {
+        Object (flat: flat);
+    }
+
+    construct {
+        var navigation_button = new Gtk.Button.with_label ("") {
+            valign = Gtk.Align.CENTER
+        };
+        navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
+
+        unfullscreen_button = new Gtk.Button.from_icon_name ("view-restore-symbolic") {
+            visible = false,
+            tooltip_text = _("Unfullscreen")
+        };
+
+        header_bar = new Gtk.HeaderBar () {
+            show_title_buttons = true,
+            hexpand = true
+        };
+        header_bar.pack_start (navigation_button);
+        header_bar.pack_end (unfullscreen_button);
+
+        if (flat) {
+            header_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        }
+
+        append (header_bar);
+
+        map.connect (() => {
+            var adjacent_page_name = ((Window) get_root ()).get_adjacent_page_name ();
+            if (adjacent_page_name != null) {
+                navigation_button.visible = true;
+                navigation_button.label = adjacent_page_name;
+            } else {
+                navigation_button.visible = false;
+            }
+
+            binding = ((Window) get_root ()).bind_property ("fullscreened", this, "fullscreened", SYNC_CREATE);
+        });
+
+        unmap.connect (() => binding.unbind ());
+
+        navigation_button.clicked.connect (() => ((Adw.Leaflet) get_ancestor (typeof (Adw.Leaflet))).navigate (BACK));
+
+        unfullscreen_button.clicked.connect (() => ((Window) get_root ()).unfullscreen ());
+    }
+}

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -1,6 +1,8 @@
-/*-
- * Copyright 2023 elementary, Inc. (https://elementary.io)
+/*
  * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2023 elementary, Inc. (https://elementary.io)
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
  */
 
 public class Audience.HeaderBar : Gtk.Box {

--- a/src/Widgets/Library/EpisodesPage.vala
+++ b/src/Widgets/Library/EpisodesPage.vala
@@ -23,7 +23,6 @@ public class Audience.EpisodesPage : Gtk.Box {
 
     private ListStore items;
     private Gtk.SearchEntry search_entry;
-    private Gtk.HeaderBar header_bar;
     private Gtk.FlowBox view_episodes;
     private Granite.Placeholder alert_view;
 
@@ -32,11 +31,6 @@ public class Audience.EpisodesPage : Gtk.Box {
     construct {
         items = new ListStore (typeof (LibraryItem));
         poster_source = null;
-
-        var navigation_button = new Gtk.Button.with_label (_("Library")) {
-            valign = Gtk.Align.CENTER
-        };
-        navigation_button.add_css_class (Granite.STYLE_CLASS_BACK_BUTTON);
 
         search_entry = new Gtk.SearchEntry () {
             placeholder_text = _("Search Videos"),
@@ -53,13 +47,9 @@ public class Audience.EpisodesPage : Gtk.Box {
         };
         settings.bind ("autoqueue-next", autoqueue_next, "active", SettingsBindFlags.DEFAULT);
 
-        header_bar = new Gtk.HeaderBar () {
-            show_title_buttons = true
-        };
-        header_bar.pack_start (navigation_button);
-        header_bar.pack_end (search_entry);
-        header_bar.pack_end (autoqueue_next);
-        header_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        var header_bar = new HeaderBar ();
+        header_bar.header_bar.pack_end (search_entry);
+        header_bar.header_bar.pack_end (autoqueue_next);
 
         poster = new Gtk.Picture () {
             height_request = Audience.Services.POSTER_HEIGHT,
@@ -110,10 +100,6 @@ public class Audience.EpisodesPage : Gtk.Box {
         orientation = VERTICAL;
         append (header_bar);
         append (grid);
-
-        navigation_button.clicked.connect (() => {
-            ((Adw.Leaflet)get_ancestor (typeof (Adw.Leaflet))).navigate (Adw.NavigationDirection.BACK);
-        });
 
         view_episodes.child_activated.connect (play_video);
 

--- a/src/Widgets/Library/LibraryPage.vala
+++ b/src/Widgets/Library/LibraryPage.vala
@@ -47,22 +47,13 @@ public class Audience.LibraryPage : Gtk.Box {
     construct {
         items = new ListStore (typeof (LibraryItem));
 
-        var navigation_button = new Gtk.Button.with_label (_("Back")) {
-            valign = Gtk.Align.CENTER
-        };
-        navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
-
         search_entry = new Gtk.SearchEntry () {
             placeholder_text = _("Search Videos"),
             valign = CENTER
         };
 
-        var header_bar = new Gtk.HeaderBar () {
-            show_title_buttons = true,
-        };
-        header_bar.pack_start (navigation_button);
-        header_bar.pack_end (search_entry);
-        header_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
+        var header_bar = new HeaderBar ();
+        header_bar.header_bar.pack_end (search_entry);
 
         view_movies = new Gtk.FlowBox () {
             column_spacing = 12,
@@ -116,10 +107,6 @@ public class Audience.LibraryPage : Gtk.Box {
             if (search_entry.text != "" && !has_child ()) {
                 search_entry.text = "";
             }
-        });
-
-        navigation_button.clicked.connect (() => {
-            ((Adw.Leaflet)get_ancestor (typeof (Adw.Leaflet))).navigate (Adw.NavigationDirection.BACK);
         });
 
         search_entry.search_changed.connect (() => filter ());

--- a/src/Widgets/Player/PlayerPage.vala
+++ b/src/Widgets/Player/PlayerPage.vala
@@ -26,7 +26,6 @@ namespace Audience {
     };
 
     public class PlayerPage : Gtk.Box {
-        private Gtk.HeaderBar header_bar;
         private Audience.Widgets.BottomBar bottom_bar;
         private Gtk.Revealer windowcontrols_revealer;
         private Gtk.Revealer bottom_bar_revealer;
@@ -36,15 +35,7 @@ namespace Audience {
         construct {
             var playback_manager = PlaybackManager.get_default ();
 
-            var navigation_button = new Gtk.Button.with_label ("") {
-                valign = Gtk.Align.CENTER
-            };
-            navigation_button.get_style_context ().add_class (Granite.STYLE_CLASS_BACK_BUTTON);
-
-            header_bar = new Gtk.HeaderBar () {
-                show_title_buttons = true
-            };
-            header_bar.pack_start (navigation_button);
+            var header_bar = new HeaderBar (false);
 
             windowcontrols_revealer = new Gtk.Revealer () {
                 transition_type = SLIDE_DOWN,
@@ -74,14 +65,6 @@ namespace Audience {
             overlay.add_overlay (bottom_bar_revealer);
 
             append (overlay);
-
-            map.connect (() => {
-                navigation_button.label = ((Window)get_root ()).get_adjacent_page_name ();
-            });
-
-            navigation_button.clicked.connect (() => {
-                ((Adw.Leaflet)get_ancestor (typeof (Adw.Leaflet))).navigate (Adw.NavigationDirection.BACK);
-            });
 
             var motion_controller = new Gtk.EventControllerMotion ();
             add_controller (motion_controller);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -87,15 +87,10 @@ public class Audience.Window : Gtk.ApplicationWindow {
             }
         });
 
-        var welcome_page_header_bar = new Gtk.HeaderBar () {
-            show_title_buttons = true
-        };
-        welcome_page_header_bar.add_css_class (Granite.STYLE_CLASS_FLAT);
-
         var welcome_page = new WelcomePage ();
 
         welcome_page_box = new Gtk.Box (VERTICAL, 0);
-        welcome_page_box.append (welcome_page_header_bar);
+        welcome_page_box.append (new HeaderBar ());
         welcome_page_box.append (welcome_page);
         welcome_page_box.add_css_class (Granite.STYLE_CLASS_VIEW);
 
@@ -187,12 +182,10 @@ public class Audience.Window : Gtk.ApplicationWindow {
     }
 
     private void action_fullscreen () {
-        if (leaflet.visible_child == player_page) {
-            if (fullscreened) {
-                unfullscreen ();
-            } else {
-                fullscreen ();
-            }
+        if (fullscreened) {
+            unfullscreen ();
+        } else {
+            fullscreen ();
         }
     }
 
@@ -411,14 +404,16 @@ public class Audience.Window : Gtk.ApplicationWindow {
         PlaybackManager.get_default ().play_file (uri, from_beginning);
     }
 
-    public string get_adjacent_page_name () {
+    public string? get_adjacent_page_name () {
         var previous_child = leaflet.get_adjacent_child (Adw.NavigationDirection.BACK);
         if (previous_child == episodes_page) {
             return _("Episodes");
         } else if (previous_child == library_page) {
             return _("Library");
-        } else {
+        } else if (previous_child == welcome_page_box) {
             return _("Back");
+        } else {
+            return null;
         }
     }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ executable(
     'Services/LibraryManager.vala',
     'Services/PlaybackManager.vala',
     'Services/Thumbnailer.vala',
+    'Widgets/HeaderBar.vala',
     'Widgets/UnsupportedFileDialog.vala',
     'Widgets/WelcomePage.vala',
     'Widgets/Library/EpisodesPage.vala',


### PR DESCRIPTION
- Make HeaderBar a separate class that handles the navigation button and therefore reduces duplicate code especially when we want to add more by default (e.g. a menu)
- It also handles switching the maximize button for a unfullscreen one when fullscreened (GNOME Videos does the same). That's because the maximize button doesn't visibly do anything when fullscreened and IMHO only confuses the user. I personally like having a unfullscreen button but another possibility would be to just hide the maximize button.
- Also fixes an issue where it would be impossible to get out of fullscreen on any other page except the PlayerPage