### PR TITLE
Bump elementary runtime and Rust SDK extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//22.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.2-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.3-${{ matrix.arch }}
       options: --privileged
 
     steps:
@@ -58,7 +58,7 @@ jobs:
     name: Gettext
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.2-x86_64
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.3-x86_64
       options: --privileged
 
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//22.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
@@ -71,6 +71,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GIT_USER_TOKEN }}
+
+    - name: Install Rust SDK extension
+      run: |
+        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
 
     - name: Configure Git
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/elementary/flatpak-platform/runtime:7.2-${{ matrix.arch }}
+      image: ghcr.io/elementary/flatpak-platform/runtime:7.3-${{ matrix.arch }}
       options: --privileged
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//22.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -27,7 +27,7 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     no-autodownload: true
     directory: lib/ffmpeg
-    version: '22.08'
+    version: '23.08'
     add-ld-path: '.'
 
 modules:
@@ -46,7 +46,7 @@ modules:
     sources:
     - type: git
       url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs
-      branch: '0.10'
+      branch: '0.12'
     build-options:
       build-args:
         - "--share=network"

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -1,6 +1,6 @@
 app-id: io.elementary.videos
 runtime: io.elementary.Platform
-runtime-version: '7.2'
+runtime-version: '7.3'
 sdk: io.elementary.Sdk
 command: io.elementary.videos
 sdk-extensions:


### PR DESCRIPTION
The build is failing due to not having new enough Rust:
https://github.com/elementary/videos/actions/runs/8862630295/job/24335796428

Also add the extension to the Gettext job while we're here, so that the meson build can succeed.