### PR TITLE
flatpak: Install gst-plugins-rs to /app/lib

### DIFF
--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -18,7 +18,7 @@ finish-args:
   - '--socket=wayland'
   - '--socket=pulseaudio'
   - '--device=dri'
-  - '--env=GST_PLUGIN_PATH_1_0=/app/lib64/gstreamer-1.0'
+  - '--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0'
 
   - '--talk-name=org.freedesktop.thumbnails.Thumbnailer1'
 
@@ -52,7 +52,7 @@ modules:
       build-args:
         - "--share=network"
     build-commands:
-      - "cargo cinstall -p gst-plugin-gtk4 --prefix=/app"
+      - "cargo cinstall -p gst-plugin-gtk4 --prefix=/app --libdir=/app/lib"
 
   - name: videos
     buildsystem: meson

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -18,6 +18,7 @@ finish-args:
   - '--socket=wayland'
   - '--socket=pulseaudio'
   - '--device=dri'
+  - '--env=GST_PLUGIN_PATH_1_0=/app/lib64/gstreamer-1.0'
 
   - '--talk-name=org.freedesktop.thumbnails.Thumbnailer1'
 

--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -18,7 +18,6 @@ finish-args:
   - '--socket=wayland'
   - '--socket=pulseaudio'
   - '--device=dri'
-  - '--env=GST_PLUGIN_PATH_1_0=/app/lib/gstreamer-1.0'
 
   - '--talk-name=org.freedesktop.thumbnails.Thumbnailer1'
 


### PR DESCRIPTION
Fixes #390

Make sure to install gst-plugins-rs to `/app/lib` where GStreamer searches for by default (set in `GST_PLUGIN_SYSTEM_PATH` environment variable).