### PR TITLE
Actions: Update org.freedesktop.Sdk.Extension.rust-stable from 23.08 to 24.08

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
@@ -75,7 +75,7 @@ jobs:
     - name: Install Rust SDK extension
       run: |
         flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install -y flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
+        flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//24.08
 
     - name: Configure Git
       run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
@@ -75,7 +75,7 @@ jobs:
     - name: Install Rust SDK extension
       run: |
         flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//24.08
+        flatpak install -y flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
 
     - name: Configure Git
       run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
@@ -75,7 +75,7 @@ jobs:
     - name: Install Rust SDK extension
       run: |
         flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//23.08
+        flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//24.08
 
     - name: Configure Git
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//23.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust SDK extension
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y --arch=${{matrix.arch}} org.freedesktop.Sdk.Extension.rust-stable//24.08
+          flatpak install -y --arch=${{matrix.arch}} flathub org.freedesktop.Sdk.Extension.rust-stable//24.08
 
       - name: Build
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6


### PR DESCRIPTION
I believe this should fix #395 is failing to build with the following error:

```
========================================================================
Building module cargo-c in /__w/videos/videos/.flatpak-builder/build/cargo-c-1
========================================================================
Running: cargo install cargo-c --root /app
    Updating crates.io index
error: cannot install package `cargo-c 0.10.9+cargo-0.85.0`, it requires rustc 1.82 or newer, while the currently active rustc version is 1.81.0
`cargo-c 0.10.7+cargo-0.84.0` supports rustc 1.81
Error: module cargo-c: Child process exited with code 101
Error: Build failed: Error: The process '/usr/bin/xvfb-run' failed with exit code 1
```