### PR TITLE
fix: pin cargo-c version

### DIFF
--- a/io.elementary.videos.yml
+++ b/io.elementary.videos.yml
@@ -34,7 +34,8 @@ modules:
   - name: cargo-c
     buildsystem: simple
     build-commands:
-      - "cargo install cargo-c --root /app"
+      # This version is locked to a version that can build with Rust 1.81 which is what's in the SDK
+      - "cargo install --locked cargo-c@0.10.7+cargo-0.84.0 --root /app"
     build-options:
       build-args:
         - "--share=network"


### PR DESCRIPTION
Pin to an earlier version that works with the version of the Rust compiler that's available in the SDK